### PR TITLE
Feat/#4 jwt 인증 인가 구현 및 auth 일부 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,16 @@ dependencies {
 
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
@@ -1,0 +1,35 @@
+package com.project.team4backend.domain.auth.contoller;
+
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.domain.auth.service.command.AuthCommandService;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.SignatureException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@Tag(name = "토큰 발급 API", description = "토큰 발급 API입니다.")
+public class AuthController {
+
+    private final AuthCommandService authCommandService;
+
+    //토큰 재발급 API
+    @Operation(method = "POST", summary = "토큰 재발급", description = "토큰 재발급. accessToken과 refreshToken을 body에 담아서 전송합니다.")
+    @PostMapping("/reissue")
+    public CustomResponse<?> reissue(@RequestBody AuthResDTO.JwtResDTO jwtResDTO) throws SignatureException {
+
+        log.info("[ Auth Controller ] 토큰을 재발급합니다. ");
+
+        return CustomResponse.onSuccess(authCommandService.reissueToken(jwtResDTO));
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
@@ -17,7 +17,7 @@ import java.security.SignatureException;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/auths")
 @Tag(name = "토큰 발급 API", description = "토큰 발급 API입니다.")
 public class AuthController {
 

--- a/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
@@ -1,0 +1,12 @@
+package com.project.team4backend.domain.auth.dto.request;
+
+import lombok.Builder;
+
+public class AuthReqDTO {
+    @Builder
+    public record LoginReqDTO(
+            String email,
+            String password
+    ) {
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/auth/dto/response/AuthResDTO.java
+++ b/src/main/java/com/project/team4backend/domain/auth/dto/response/AuthResDTO.java
@@ -1,0 +1,18 @@
+package com.project.team4backend.domain.auth.dto.response;
+
+import lombok.Builder;
+
+public class AuthResDTO {
+    @Builder
+    public record JwtResDTO(
+            String accessToken,
+            String refreshToken
+    ){}
+
+    @Builder
+    public record LoginResDTO(
+            String nickname,
+            String accessToken,
+            String refreshToken
+    ){}
+}

--- a/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
@@ -1,4 +1,27 @@
 package com.project.team4backend.domain.auth.entity;
 
+import com.project.team4backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Auth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "is_temp")
+    private IsTempPassword isTempPassword;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/com/project/team4backend/domain/auth/entity/IsTempPassword.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/IsTempPassword.java
@@ -1,0 +1,5 @@
+package com.project.team4backend.domain.auth.entity;
+
+public enum IsTempPassword {
+    NORMAL, IS_TEMP_PASSWORD
+}

--- a/src/main/java/com/project/team4backend/domain/auth/entity/Token.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/Token.java
@@ -1,0 +1,22 @@
+package com.project.team4backend.domain.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "token")
+public class Token {
+
+    @Id
+    private String email;
+    private String token;
+}

--- a/src/main/java/com/project/team4backend/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.project.team4backend.domain.auth.exception;
+
+import com.project.team4backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    _INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_402", "인증이 필요합니다"),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근이 금지되었습니다"),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404","찾을 수 없습니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/team4backend/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/project/team4backend/domain/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package com.project.team4backend.domain.auth.exception;
+
+import com.project.team4backend.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends CustomException {
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/project/team4backend/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,16 @@
+package com.project.team4backend.domain.auth.repository;
+
+import com.project.team4backend.domain.auth.entity.Auth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AuthRepository extends JpaRepository<Auth, Long> {
+    // member의 id를 통해 해당 member의 auth정 보 가져오기
+    @Query("SELECT a from Auth a WHERE a.member.id = :memberId")
+    Optional<Auth> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/project/team4backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,32 @@
+package com.project.team4backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final Duration REFRESH_TOKEN_EXPIRATION = Duration.ofDays(1); // 1일
+
+    public void saveRefreshToken(String email, String refreshToken) {
+        redisTemplate.opsForValue().set(getKey(email), refreshToken, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get(getKey(email));
+    }
+
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete(getKey(email));
+    }
+
+    private String getKey(String email) {
+        return "refresh:" + email;
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/AuthCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/AuthCommandService.java
@@ -1,0 +1,7 @@
+package com.project.team4backend.domain.auth.service.command;
+
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+
+public interface AuthCommandService {
+    AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto);
+}

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/AuthCommandServiceImpl.java
@@ -1,0 +1,40 @@
+package com.project.team4backend.domain.auth.service.command;
+
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.domain.auth.exception.AuthErrorCode;
+import com.project.team4backend.domain.auth.exception.AuthException;
+import com.project.team4backend.global.security.JwtUtil;
+import com.project.team4backend.domain.auth.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthCommandServiceImpl implements AuthCommandService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+    public AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto) {
+
+        log.info("[ Auth Service ] 토큰 재발급을 시작합니다.");
+        String refreshToken = jwtDto.refreshToken();
+
+        //Access Token 으로부터 사용자 Email 추출
+        String email = jwtUtil.getEmail(refreshToken); // **수정부분**
+        log.info("[ Auth Service ] Email ---> {}", email);
+
+        String storedToken = refreshTokenService.getRefreshToken(email);
+        if (storedToken == null || !storedToken.equals(refreshToken)) {
+            throw new AuthException(AuthErrorCode._INVALID_TOKEN);
+        }
+        //Refresh Token 이 유효한지 검사
+        jwtUtil.validateToken(refreshToken);
+
+        log.info("[ Auth Service ] Refresh Token 이 유효합니다.");
+
+        return jwtUtil.reissueToken(refreshToken);
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/member/entity/Gender.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.project.team4backend.domain.member.entity;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -1,4 +1,46 @@
 package com.project.team4backend.domain.member.entity;
 
-public class Member {
+import com.project.team4backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name= "birthday", nullable = false)
+    private LocalDate birthday;
+
+    @Column(name= "height", nullable = false)
+    private Double height;
+
+    @Column(name= "weight", nullable = false)
+    private Double weight;
+
+    @Column(name= "gender", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private Role role;
 }

--- a/src/main/java/com/project/team4backend/domain/member/entity/Role.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package com.project.team4backend.domain.member.entity;
+
+public enum Role {
+    ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/java/com/project/team4backend/global/BaseEntity.java
+++ b/src/main/java/com/project/team4backend/global/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.project.team4backend.global;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/project/team4backend/global/security/Config/CorsConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/CorsConfig.java
@@ -1,0 +1,48 @@
+package com.project.team4backend.global.security.Config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CorsConfig implements WebMvcConfigurer {
+
+    public static CorsConfigurationSource apiConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        //데이터 교환이 가능한 URL 지정
+        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
+        allowedOriginPatterns.add("http://localhost:8080");
+        allowedOriginPatterns.add("http://localhost:3000");
+        allowedOriginPatterns.add("http://127.0.0.1:8080");
+        allowedOriginPatterns.add("http://127.0.0.1:3000");
+
+
+        //허용하는 HTTP METHOD 지정
+        ArrayList<String> allowedHttpMethods = new ArrayList<>();
+        allowedHttpMethods.add("GET");
+        allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PUT");
+        allowedHttpMethods.add("DELETE");
+
+        configuration.setAllowedOrigins(allowedOriginPatterns);
+        configuration.setAllowedMethods(allowedHttpMethods);
+
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE));
+        configuration.setAllowCredentials(true); //credential TRUE
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/Config/RedisConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.project.team4backend.global.security.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setDatabase(0);
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(factory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
@@ -1,0 +1,89 @@
+package com.project.team4backend.global.security.Config;
+
+
+import com.project.team4backend.global.security.JwtUtil;
+import com.project.team4backend.global.security.filter.CustomLoginFilter;
+import com.project.team4backend.global.security.filter.ForcePasswordChangeFilter;
+import com.project.team4backend.global.security.filter.JwtAuthorizationFilter;
+import com.project.team4backend.global.security.handler.CustomLogoutHandler;
+import com.project.team4backend.global.security.handler.CustomLogoutSuccessHandler;
+import com.project.team4backend.global.security.handler.JwtAccessDeniedHandler;
+import com.project.team4backend.global.security.handler.JwtAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration // 빈 등록
+@EnableWebSecurity // 필터 체인 관리 시작 어노테이션
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomLogoutHandler customLogoutHandler;
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    //인증이 필요하지 않은 url
+    private final String[] allowUrl = {
+            "/auths/login", //로그인 은 인증이 필요하지 않음
+            "/auths/signup", // 회원가입은 인증이 필요하지 않음
+            "/auths/login/kakao",
+            "/auths/send-temp-password",
+            "/auth/reissue", // 토큰 재발급은 인증이 필요하지 않음
+            "/auth/**",
+            "api/usage",
+            "/swagger-ui/**",   // swagger 관련 URL
+            "/v3/api-docs/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        CustomLoginFilter loginFilter = new CustomLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        loginFilter.setFilterProcessesUrl("/members/login");
+
+        http
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/", "/index", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers(allowUrl).permitAll()
+                        .requestMatchers(HttpMethod.GET).permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new ForcePasswordChangeFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .logout(logout -> logout.logoutUrl("/members/logout")
+                        .addLogoutHandler(customLogoutHandler)
+                        .logoutSuccessHandler(customLogoutSuccessHandler)
+                );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){return new BCryptPasswordEncoder();}
+}

--- a/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
@@ -40,11 +40,11 @@ public class SecurityConfig {
 
     //인증이 필요하지 않은 url
     private final String[] allowUrl = {
-            "/auths/login", //로그인 은 인증이 필요하지 않음
-            "/auths/signup", // 회원가입은 인증이 필요하지 않음
-            "/auths/login/kakao",
-            "/auths/send-temp-password",
-            "/auth/reissue", // 토큰 재발급은 인증이 필요하지 않음
+            "/api/v1/auths/login", //로그인 은 인증이 필요하지 않음
+            "/api/v1/auths/signup", // 회원가입은 인증이 필요하지 않음
+            "/api/v1/auths/login/kakao",
+            "/api/v1/auths/reset-temp-password",
+            "/api/v1/auth/reissue", // 토큰 재발급은 인증이 필요하지 않음
             "/auth/**",
             "api/usage",
             "/swagger-ui/**",   // swagger 관련 URL
@@ -54,7 +54,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
         CustomLoginFilter loginFilter = new CustomLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
-        loginFilter.setFilterProcessesUrl("/members/login");
+        loginFilter.setFilterProcessesUrl("/api/v1/auths/login");
 
         http
                 .authorizeHttpRequests(request -> request

--- a/src/main/java/com/project/team4backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/project/team4backend/global/security/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.project.team4backend.global.security;
 
-//import com.project.team4backend.domain.member.entity.IsTempPassword;
+import com.project.team4backend.domain.auth.entity.IsTempPassword;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -17,14 +17,14 @@ public class CustomUserDetails implements UserDetails {
 
     private final String email;
     private final String password;
-    private final String roles;
-    //private final IsTempPassword isTempPassword;
+    private final String role;
+    private final IsTempPassword isTempPassword;
 
     // 해당 User 의 권한을 return
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority(String.valueOf(roles)));
+        authorities.add(new SimpleGrantedAuthority(role));
         return authorities;
     }
     

--- a/src/main/java/com/project/team4backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/project/team4backend/global/security/CustomUserDetails.java
@@ -1,0 +1,69 @@
+package com.project.team4backend.global.security;
+
+//import com.project.team4backend.domain.member.entity.IsTempPassword;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final String email;
+    private final String password;
+    private final String roles;
+    //private final IsTempPassword isTempPassword;
+
+    // 해당 User 의 권한을 return
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(String.valueOf(roles)));
+        return authorities;
+    }
+    
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    // Account 가 만료되었는지?
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    // Account 가 잠겨있는지?
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    // Credential 만료되지 않았는지?
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 활성화가 되어있는지?
+    @Override
+    public boolean isEnabled() {
+        // User Entity 에서 Status 가져온 후 true? false? 검사
+        return true;
+    }
+}
+
+
+
+

--- a/src/main/java/com/project/team4backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/project/team4backend/global/security/CustomUserDetailsService.java
@@ -1,0 +1,41 @@
+package com.project.team4backend.global.security;
+
+import com.project.team4backend.domain.auth.entity.Auth;
+import com.project.team4backend.domain.auth.repository.AuthRepository;
+import com.project.team4backend.domain.member.entity.Member;
+import com.project.team4backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    private final AuthRepository authRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        log.info("[ CustomUserDetailsService ] Email을 이용하여 User 검색");
+        Optional<Member> userEntity = memberRepository.findByEmail(email);
+
+        if (userEntity.isPresent()) {
+            Member member = userEntity.get();
+            String role = String.valueOf(member.getRole());
+
+            Optional<Auth> authEntity = authRepository.findByMemberId(member.getId());
+            Auth auth = authEntity.get();
+
+            return new CustomUserDetails(member.getEmail(), auth.getPassword(), role, auth.getIsTempPassword());
+        }
+        throw new UsernameNotFoundException("사용자가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/JwtUtil.java
+++ b/src/main/java/com/project/team4backend/global/security/JwtUtil.java
@@ -1,0 +1,183 @@
+package com.project.team4backend.global.security;
+
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.domain.auth.entity.IsTempPassword;
+import com.project.team4backend.domain.auth.service.RefreshTokenService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import io.jsonwebtoken.security.SignatureException;
+import java.time.Instant;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Long accessExpMs;
+    private final Long refreshExpMs;
+    private final RefreshTokenService refreshTokenService;
+
+    public JwtUtil(
+            @Value("${spring.jwt.secret}") String secret,
+            @Value("${spring.jwt.token.access-expiration-time}") Long access,
+            @Value("${spring.jwt.token.refresh-expiration-time}") Long refresh,
+            RefreshTokenService refreshTokenService
+    ) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm());
+        accessExpMs = access;
+        refreshExpMs = refresh;
+        this.refreshTokenService = refreshTokenService;
+
+    }
+
+    public String getEmail(String token) throws SignatureException {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    // JWT 토큰을 입력으로 받아 토큰의 claim 에서 사용자 권한을 추출하는 메서드
+    public String getRoles(String token) throws SignatureException{
+        log.info("[ JwtUtil ] 토큰에서 권한을 추출합니다.");
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    public IsTempPassword getIsTempPassword(String token) throws SignatureException {
+        String tempPwdStr = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("isTempPassword", String.class);
+        return IsTempPassword.valueOf(tempPwdStr);
+    }
+
+    // Token 발급하는 메서드
+    public String tokenProvider(CustomUserDetails customUserDetails, Instant expiration) {
+
+        log.info("[ JwtUtil ] 토큰을 새로 생성합니다.");
+        //현재 시간
+        Instant issuedAt = Instant.now();
+
+        return Jwts.builder()
+                .header() //헤더 부분
+                .add("typ", "JWT") // JWT type
+                .and()
+                .subject(customUserDetails.getUsername()) //Subject 에 username (email) 추가
+                .claim("isTempPassword", customUserDetails.getIsTempPassword().name()) // 비밀번호 상태 추가
+                .issuedAt(Date.from(issuedAt)) // 현재 시간 추가
+                .expiration(Date.from(expiration)) //만료 시간 추가
+                .signWith(secretKey) //signature 추가
+                .compact(); //합치기
+    }
+
+    // principalDetails 객체에 대해 새로운 JWT 액세스 토큰을 생성
+    public String createJwtAccessToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(accessExpMs);
+        return tokenProvider(customUserDetails, expiration);
+    }
+
+    // principalDetails 객체에 대해 새로운 JWT 리프레시 토큰을 생성
+    public String createJwtRefreshToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(refreshExpMs);
+        String refreshToken = tokenProvider(customUserDetails, expiration);
+
+        // Redis에 Refresh Token 저장
+        refreshTokenService.saveRefreshToken(customUserDetails.getUsername(), refreshToken);
+        return refreshToken;
+    }
+
+    // 제공된 리프레시 토큰을 기반으로 JwtDto 쌍을 다시 발급
+    public AuthResDTO.JwtResDTO reissueToken(String refreshToken) throws SignatureException {
+
+        // refreshToken 에서 user 정보를 가져와서 새로운 토큰을 발급 (발급 시간, 유효 시간(reset)만 새로 적용)
+        CustomUserDetails userDetails = new CustomUserDetails(
+                getEmail(refreshToken),
+                null,
+                getRoles(refreshToken),
+                getIsTempPassword(refreshToken)
+        );
+        log.info("[ JwtUtil ] 새로운 토큰을 재발급 합니다.");
+
+        // 재발급
+        return new AuthResDTO.JwtResDTO(
+                createJwtAccessToken(userDetails),
+                createJwtRefreshToken(userDetails)
+        );
+    }
+
+    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰을 검색
+    public String resolveAccessToken(HttpServletRequest request) {
+        log.info("[ JwtUtil ] 헤더에서 토큰을 추출합니다.");
+        String tokenFromHeader = request.getHeader("Authorization");
+
+        if (tokenFromHeader == null || !tokenFromHeader.startsWith("Bearer ")) {
+            log.warn("[ JwtUtil ] Request Header 에 토큰이 존재하지 않습니다.");
+            return null;
+        }
+
+        log.info("[ JwtUtil ] 헤더에 토큰이 존재합니다.");
+
+        return tokenFromHeader.split(" ")[1]; //Bearer 와 분리
+    }
+
+
+    public void validateToken(String token) {
+        log.info("[ JwtUtil ] 토큰의 유효성을 검증합니다.");
+        try {
+            // 구문 분석 시스템의 시계가 JWT를 생성한 시스템의 시계 오차 고려
+            // 약 3분 허용.
+            long seconds = 3 *60;
+            boolean isExpired = Jwts
+                    .parser()
+                    .clockSkewSeconds(seconds)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration()
+                    .before(new Date());
+            if (isExpired) {
+                log.info("만료된 JWT 토큰입니다.");
+            }
+
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            //원하는 Exception throw
+            throw new SecurityException("잘못된 토큰입니다.");
+        } catch (ExpiredJwtException e) {
+            //원하는 Exception throw
+            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+        }
+    }
+    // 레디스에서 리프레시 토큰의 보관 시간 관련 메서드
+    public long getExpiration(String token) {
+        Date expiration = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/CustomLoginFilter.java
@@ -1,0 +1,146 @@
+package com.project.team4backend.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.domain.auth.dto.request.AuthReqDTO;
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.global.security.CustomUserDetails;
+import com.project.team4backend.global.security.JwtUtil;
+import com.project.team4backend.domain.auth.dto.response.AuthResDTO.JwtResDTO;
+import com.project.team4backend.domain.auth.exception.AuthErrorCode;
+import com.project.team4backend.domain.auth.exception.AuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    //로그인 시도 메서드
+    @Override
+    public Authentication attemptAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response) throws AuthenticationException {
+
+        log.info("[ Login Filter ]  로그인 시도 : Custom Login Filter 작동 ");
+        ObjectMapper objectMapper = new ObjectMapper();
+        AuthReqDTO.LoginReqDTO requestBody;
+        try {
+            requestBody = objectMapper.readValue(request.getInputStream(), AuthReqDTO.LoginReqDTO.class);
+        } catch (IOException e) {
+            throw new AuthException(AuthErrorCode._NOT_FOUND);
+        }
+
+        //Request Body 에서 추출
+        String email = requestBody.email(); //Email 추출
+        String password = requestBody.password(); //password 추출
+        log.info("[ Login Filter ]  Email ---> {} ", email);
+        log.info("[ Login Filter ]  Password ---> {} ", password);
+
+        //UserNamePasswordToken 생성 (인증용 객체)
+        UsernamePasswordAuthenticationToken authToken
+                = new UsernamePasswordAuthenticationToken(email, password, null);
+
+
+        log.info("[ Login Filter ] 인증용 객체 UsernamePasswordAuthenticationToken 이 생성되었습니다. ");
+        log.info("[ Login Filter ] 인증을 시도합니다.");
+
+        //인증 시도
+        return authenticationManager.authenticate(authToken);
+    }
+
+    //로그인 성공시
+    @Override
+    protected void successfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain,
+            @NonNull Authentication authentication) throws IOException {
+
+
+        log.info("[ Login Filter ] 로그인에 성공 하였습니다.");
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+
+        // JWT 생성
+        //Client 에게 줄 Response 를 Build
+        String accessToken = jwtUtil.createJwtAccessToken(customUserDetails); //access token 생성
+        String refreshToken = jwtUtil.createJwtRefreshToken(customUserDetails); //refresh token 생성
+
+        // CustomResponse 사용하여 응답 통일
+        AuthResDTO.LoginResDTO jwtLoginResDTO = AuthResDTO.LoginResDTO.builder()
+                .nickname(customUserDetails.getUsername())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        CustomResponse<AuthResDTO.LoginResDTO> responseBody = CustomResponse.onSuccess(jwtLoginResDTO);
+
+        //JSON 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(HttpStatus.OK.value()); //Response 의 Status 를 200으로 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        //Body 에 토큰이 담긴 Response 쓰기
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull AuthenticationException failed) throws IOException {
+
+        log.info("[ Login Filter ] 로그인에 실패하였습니다.");
+
+        String errorCode;
+        String errorMessage;
+
+        if (failed instanceof BadCredentialsException) {
+            errorCode = String.valueOf(HttpStatus.UNAUTHORIZED.value());
+            errorMessage = "잘못된 정보입니다.";
+        } else if (failed instanceof LockedException) {
+            errorCode = String.valueOf(HttpStatus.LOCKED.value());
+            errorMessage = "계정이 잠금 상태입니다.";
+        } else if (failed instanceof DisabledException) {
+            errorCode = String.valueOf(HttpStatus.FORBIDDEN.value());
+            errorMessage = "계정이 비활성화 되었습니다.";
+        } else if (failed instanceof UsernameNotFoundException) {
+            errorCode = String.valueOf(HttpStatus.NOT_FOUND.value());
+            errorMessage = "계정을 찾을 수 없습니다.";
+        } else if (failed instanceof AuthenticationServiceException) {
+            errorCode = String.valueOf(HttpStatus.BAD_REQUEST.value());
+            errorMessage = "Request Body 파싱 중 오류가 발생했습니다.";
+        } else {
+            errorCode = String.valueOf(HttpStatus.UNAUTHORIZED.value());
+            errorMessage = "인증에 실패했습니다.";
+        }
+
+        // CustomResponse 사용하여 응답 통일
+        CustomResponse<JwtResDTO> responseBody = CustomResponse.onFailure(errorCode, errorMessage);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(Integer.parseInt(errorCode)); // HTTP 상태 코드 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody)); // 응답 변환 및 출력
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
@@ -1,0 +1,67 @@
+package com.project.team4backend.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.domain.auth.entity.IsTempPassword;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.global.security.CustomUserDetails;
+import com.project.team4backend.domain.auth.exception.AuthErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ForcePasswordChangeFilter extends OncePerRequestFilter {
+    private static final List<String> ALLOWED_PATHS = List.of(
+            "/api/v1/auths/password-reset", "/api/v1/auths/reissue"
+    );
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+            if (userDetails.getIsTempPassword() == IsTempPassword.IS_TEMP_PASSWORD) {
+                // 허용된 경로 외에는 전부 차단
+                String requestURI = request.getRequestURI();
+                boolean isAllowed = ALLOWED_PATHS.stream().anyMatch(requestURI::startsWith);
+                if (!isAllowed) {
+                    log.warn("[ ForcePasswordChangeFilter ] 임시 비밀번호 상태로 허용되지 않은 경로 접근 시도");
+                    String errorCode = AuthErrorCode._FORBIDDEN.getCode();
+                    String errorMessage = AuthErrorCode._FORBIDDEN.getMessage();
+
+                    CustomResponse<String> responseBody = CustomResponse.onFailure(errorCode, errorMessage);
+
+                    //JSON 변환
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    response.setStatus(HttpStatus.FORBIDDEN.value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.setCharacterEncoding("UTF-8");
+
+                    //Body 에 토큰이 담긴 Response 쓰기
+                    response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+                    return;
+                }
+            }
+        }
+
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,103 @@
+package com.project.team4backend.global.security.filter;
+
+import com.project.team4backend.domain.auth.entity.IsTempPassword;
+import com.project.team4backend.global.security.CustomUserDetails;
+import com.project.team4backend.global.security.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    // JWT 관련 유틸리티 클래스 주입
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate; // 필드 추가 필요
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        log.info("[ JwtAuthorizationFilter ] 인가 필터 작동");
+
+        try {
+            // 1. Request에서 Access Token 추출
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            // 2. Access Token이 없으면 다음 필터로 바로 진행
+            if (accessToken == null) {
+                log.info("[ JwtAuthorizationFilter ] 토큰이 존재하지 않습니다. 다음 필터로 진행.");
+                filterChain.doFilter(request, response);
+                return;
+            }
+            //블랙리스트 token이어도 일단 리턴
+            if (redisTemplate.hasKey("blacklist:" + accessToken)) {
+                log.warn("[ JwtAuthorizationFilter ] 로그아웃된 accessToken 입니다.");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 3. Access Token을 이용한 인증 처리
+            authenticateAccessToken(accessToken);
+            log.info("[ JwtAuthorizationFilter ] 종료. 다음 필터로 넘어갑니다.");
+
+        } catch (ExpiredJwtException e) {
+            // 4. 토큰 만료 시 401 응답 처리
+            logger.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("Access Token 이 만료되었습니다.");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // Access Token을 바탕으로 인증 객체 생성 및 SecurityContext에 저장
+    private void authenticateAccessToken(String accessToken) {
+
+        log.info("[ JwtAuthorizationFilter ] 토큰으로 인가 과정을 시작합니다. ");
+
+        // 1. Access Token의 유효성 검증
+        jwtUtil.validateToken(accessToken);
+
+        log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공. ");
+
+        // 2. Access Token에서 사용자 정보 추출 후 CustomUserDetails 생성
+        String email = jwtUtil.getEmail(accessToken);
+        String role = jwtUtil.getRoles(accessToken);
+        IsTempPassword isTempPassword = jwtUtil.getIsTempPassword(accessToken);
+
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(email, null, role, isTempPassword);
+
+        log.info("[ JwtAuthorizationFilter ] UserDetails 객체 생성 성공");
+
+        // 3. 인증 객체 생성 및 SecurityContextHolder에 저장
+
+        List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority((role)));
+
+        System.out.println("권한 리스트: " + customUserDetails.getAuthorities());
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("[ JwtAuthorizationFilter ] 인증 객체 저장 완료");
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
@@ -1,0 +1,48 @@
+package com.project.team4backend.global.security.handler;
+
+import com.project.team4backend.global.security.JwtUtil;
+import com.project.team4backend.domain.auth.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            if (accessToken != null) {
+                jwtUtil.validateToken(accessToken);
+                String email = jwtUtil.getEmail(accessToken);
+
+                long expiration = jwtUtil.getExpiration(accessToken);
+
+                redisTemplate.opsForValue().set("blacklist:" + accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+                log.info("[LogoutHandler] Access Token 블랙리스트 등록 완료");
+
+                //Refresh Token Redis에서 삭제
+                refreshTokenService.deleteRefreshToken(email);
+                log.info("[LogoutHandler] Redis에서 Refresh Token 삭제 완료");
+            }
+
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,29 @@
+package com.project.team4backend.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        CustomResponse<String> responseBody = CustomResponse.onSuccess("로그아웃 성공");
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.project.team4backend.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.domain.auth.exception.AuthErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(403);
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                AuthErrorCode._FORBIDDEN.getCode(),
+                AuthErrorCode._FORBIDDEN.getMessage(),
+                null
+        );
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.project.team4backend.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.domain.auth.exception.AuthErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(401);
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                AuthErrorCode._UNAUTHORIZED.getCode(),
+                AuthErrorCode._UNAUTHORIZED.getMessage(),
+                null
+        );
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #5 

##  📌 개요

- security, jwt, redis 의존성 추가
- 인증 인가 관련 파일 생성 및 로그인 로그아웃 관련 필터,핸들러만 구현 (서비스 기능 x)
- 리프레시 토큰 재발급 관련 기능 구현
- member 엔티티와 Gender, Role 구현
- Auth 엔티티와 IsTempPassword 구현
+ BaseEntity 구현
## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 기존에 없던 Role을 member 필드에 추가했습니다. 딱히 우리 기능에 권한 관련 기능은 없지만 유지보수를 생각해서 그냥 틀만 만들자는 생각으로 구현했는데, 일단은 회원가입 시, 전부 ROLE_USER로 고정해서 생성되도록 하면 될 것 같습니다.

+ 생각없이 전부 feat으로 해버렷네요 다음 pr부턴 신경쓰겠습니다..