### PR TITLE
Feat/#11 비밀번호 변경 임시 비밀번호 발급 api 구현

### DIFF
--- a/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
@@ -9,10 +9,12 @@ import com.project.team4backend.domain.auth.service.command.auth.AuthCommandServ
 import com.project.team4backend.domain.auth.service.command.email.EmailVerificationCommandService;
 import com.project.team4backend.domain.member.repository.MemberRepository;
 import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,6 +51,17 @@ public class AuthController {
     @Operation(method = "POST", summary = "로그아웃", description = "security handler에서 처리")
     @PostMapping("/logout")
     public void logout() {
+    }
+
+    @Operation(method = "POST", summary ="비밀번호 변경", description = "비밀번호 변경 api인데, 정확히는 비밀번호를 입력해서 수정이 아닌 새로 생성해서 덮어쓰기")
+    @PostMapping("/reset-password")
+    public CustomResponse<String> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody AuthReqDTO.UpdatePasswordReqDTO updatePasswordReqDTO){
+        //이메일 인증 코드 검증
+        EmailVerification emailVerification = emailVerificationCommandService.checkVerificationCode(EmailVerificationConverter.toEmailVerifyReqDTO(customUserDetails.getEmail(), updatePasswordReqDTO.authCode(), Type.CHANGE_PASSWORD));
+        authCommandService.updatePassword(updatePasswordReqDTO, emailVerification);
+        return CustomResponse.onSuccess("비밀번호가 변경 되었습니다.");
     }
 
     //토큰 재발급 API

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
@@ -55,13 +55,22 @@ public class AuthController {
 
     @Operation(method = "POST", summary ="비밀번호 변경", description = "비밀번호 변경 api인데, 정확히는 비밀번호를 입력해서 수정이 아닌 새로 생성해서 덮어쓰기")
     @PostMapping("/reset-password")
-    public CustomResponse<String> updatePassword(
+    public CustomResponse<String> resetUpdatePassword(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody AuthReqDTO.UpdatePasswordReqDTO updatePasswordReqDTO){
         //이메일 인증 코드 검증
         EmailVerification emailVerification = emailVerificationCommandService.checkVerificationCode(EmailVerificationConverter.toEmailVerifyReqDTO(customUserDetails.getEmail(), updatePasswordReqDTO.authCode(), Type.CHANGE_PASSWORD));
         authCommandService.updatePassword(updatePasswordReqDTO, emailVerification);
         return CustomResponse.onSuccess("비밀번호가 변경 되었습니다.");
+    }
+
+    @Operation(method = "POST", summary = "임시 비밀번호 발급", description = "이메일 인증을 통해 임시 비밀번호를 이메일로 전송")
+    @PostMapping("/reset-temp-password")
+    public CustomResponse<String> resetTempPassword(@RequestBody AuthReqDTO.TempPasswordReqDTO tempPasswordReqDTO){
+        //이메일 인증 코드 검증
+        EmailVerification emailVerification = emailVerificationCommandService.checkVerificationCode(EmailVerificationConverter.toEmailVerifyReqDTO(tempPasswordReqDTO.email(), tempPasswordReqDTO.authCode(), Type.TEMP_PASSWORD));
+        authCommandService.updateTempPassword(tempPasswordReqDTO, emailVerification);
+        return CustomResponse.onSuccess("임시 비밀번호가 전송되었습니다.");
     }
 
     //토큰 재발급 API

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/AuthController.java
@@ -1,8 +1,10 @@
 package com.project.team4backend.domain.auth.contoller;
 
+import com.project.team4backend.domain.auth.converter.EmailVerificationConverter;
 import com.project.team4backend.domain.auth.dto.request.AuthReqDTO;
-import com.project.team4backend.domain.auth.dto.request.EmailVerificationReqDTO;
 import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.domain.auth.entity.EmailVerification;
+import com.project.team4backend.domain.auth.entity.enums.Type;
 import com.project.team4backend.domain.auth.service.command.auth.AuthCommandService;
 import com.project.team4backend.domain.auth.service.command.email.EmailVerificationCommandService;
 import com.project.team4backend.domain.member.repository.MemberRepository;
@@ -22,7 +24,7 @@ import java.security.SignatureException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auths")
-@Tag(name = "Auth 관련 api", description = "Auth 관련 API입니다.")
+@Tag(name = "Auth API", description = "Auth 관련 API입니다.")
 public class AuthController {
 
     private final AuthCommandService authCommandService;
@@ -35,13 +37,8 @@ public class AuthController {
     @PostMapping("/signup")
     public CustomResponse<AuthResDTO.SignUpResDTO> signIn(@RequestBody AuthReqDTO.SignupReqDTO signupReqDTO) {
         //이메일 인증 코드 검증
-        emailVerificationCommandService.checkVerificationCode(
-                new EmailVerificationReqDTO.EmailVerifyReqDTO(
-                        signupReqDTO.email(),
-                        signupReqDTO.authCode()
-                )
-        );
-        return CustomResponse.onSuccess(authCommandService.signUp(signupReqDTO));
+        EmailVerification emailVerification = emailVerificationCommandService.checkVerificationCode(EmailVerificationConverter.toEmailVerifyReqDTO(signupReqDTO.email(), signupReqDTO.authCode(), Type.SIGNUP));
+        return CustomResponse.onSuccess(authCommandService.signUp(signupReqDTO,emailVerification));
     }
 
     @Operation(method = "POST", summary = "로그인", description = "jwt 발급은 필터에서 처리된다.")

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
@@ -39,8 +39,8 @@ public class EmailVerificationController {
             }
         }
 
-        String code = emailVerificationCommandService.createEmailVerification(emailSendReqDTO); // 이메일인증 정보 생성
-        emailVerificationCommandService.sendVerificationCode(emailSendReqDTO.email(), code); // 인증 코드 전송
+        String message = emailVerificationCommandService.createEmailVerification(emailSendReqDTO); // 이메일인증 정보 생성
+        emailVerificationCommandService.sendVerificationCode(emailSendReqDTO.email(), message); // 인증 코드 전송
         return CustomResponse.onSuccess("이메일 인증 코드가 전송 되었습니다.");
     }
 

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "EmailVerification 관련 api", description = "EmailVerification 관련 API입니다.")
+@Tag(name = "EmailVerification API", description = "EmailVerification 관련 API입니다.")
 @RequestMapping("/api/v1/auths/emailVerifications")
 public class EmailVerificationController {
 
@@ -47,7 +47,7 @@ public class EmailVerificationController {
     @Operation(method = "POST", summary = "이메일 인증 코드 검증", description = "이메일 인증용 코드를 db에 저장된 정보와 비교")
     @PostMapping("/check")
     public CustomResponse<String> CheckEmailVerificationCode(@RequestBody EmailVerificationReqDTO.EmailVerifyReqDTO emailVerifyReqDTO) {
-        emailVerificationCommandService.checkVerificationCode(emailVerifyReqDTO);
+        emailVerificationCommandService.emailVerificationAndMark(emailVerifyReqDTO);
         return CustomResponse.onSuccess("이메일 인증 완료 되었습니다.");
     }
 }

--- a/src/main/java/com/project/team4backend/domain/auth/converter/EmailVerificationConverter.java
+++ b/src/main/java/com/project/team4backend/domain/auth/converter/EmailVerificationConverter.java
@@ -2,6 +2,7 @@ package com.project.team4backend.domain.auth.converter;
 
 import com.project.team4backend.domain.auth.dto.request.EmailVerificationReqDTO;
 import com.project.team4backend.domain.auth.entity.EmailVerification;
+import com.project.team4backend.domain.auth.entity.enums.Type;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -13,9 +14,18 @@ public class EmailVerificationConverter {
         return EmailVerification.builder()
                 .email(emailSendReqDTO.email())
                 .code(code)
+                .type(emailSendReqDTO.type())
                 .createdAt(LocalDateTime.now())
                 .expireAt(LocalDateTime.now().plusMinutes(3))
                 .isVerified(false)
+                .build();
+    }
+
+    public static EmailVerificationReqDTO.EmailVerifyReqDTO toEmailVerifyReqDTO(String email, String authCode, Type type) {
+        return EmailVerificationReqDTO.EmailVerifyReqDTO.builder()
+                .email(email)
+                .authCode(authCode)
+                .type(type)
                 .build();
     }
 }

--- a/src/main/java/com/project/team4backend/domain/auth/converter/EmailVerificationConverter.java
+++ b/src/main/java/com/project/team4backend/domain/auth/converter/EmailVerificationConverter.java
@@ -10,10 +10,10 @@ import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailVerificationConverter {
-    public static EmailVerification toEmailVerification(EmailVerificationReqDTO.EmailSendReqDTO emailSendReqDTO, String code) {
+    public static EmailVerification toEmailVerification(EmailVerificationReqDTO.EmailSendReqDTO emailSendReqDTO, String message) {
         return EmailVerification.builder()
                 .email(emailSendReqDTO.email())
-                .code(code)
+                .message(message)
                 .type(emailSendReqDTO.type())
                 .createdAt(LocalDateTime.now())
                 .expireAt(LocalDateTime.now().plusMinutes(3))

--- a/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
@@ -22,12 +22,19 @@ public class AuthReqDTO {
     public record LoginReqDTO(
             String email,
             String password
-    ) {
+    ){
     }
     @Builder
     public record UpdatePasswordReqDTO(
             String currentPassword,
             String newPassword,
+            String authCode
+    ){
+    }
+
+    @Builder
+    public record TempPasswordReqDTO(
+            String email,
             String authCode
     ){
     }

--- a/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/auth/dto/request/AuthReqDTO.java
@@ -24,4 +24,11 @@ public class AuthReqDTO {
             String password
     ) {
     }
+    @Builder
+    public record UpdatePasswordReqDTO(
+            String currentPassword,
+            String newPassword,
+            String authCode
+    ){
+    }
 }

--- a/src/main/java/com/project/team4backend/domain/auth/dto/request/EmailVerificationReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/auth/dto/request/EmailVerificationReqDTO.java
@@ -1,12 +1,14 @@
 package com.project.team4backend.domain.auth.dto.request;
 
 import com.project.team4backend.domain.auth.entity.enums.Type;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 public class EmailVerificationReqDTO {
     @Builder
     public record EmailSendReqDTO(
             String email,
+            @Schema(description = "인증 요청 목적", example = "SIGNUP")
             Type type
     ){
     }
@@ -14,7 +16,9 @@ public class EmailVerificationReqDTO {
     @Builder
     public record EmailVerifyReqDTO(
             String email,
-            String authCode
+            String authCode,
+            @Schema(description = "인증 요청 목적", example = "SIGNUP")
+            Type type
     ){
     }
 }

--- a/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
@@ -27,4 +27,8 @@ public class Auth {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
@@ -31,4 +31,8 @@ public class Auth {
         this.password = password;
     }
 
+    public void updateIsTempPassword(IsTempPassword isTempPassword) {
+        this.isTempPassword = isTempPassword;
+    }
+
 }

--- a/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/Auth.java
@@ -20,6 +20,7 @@ public class Auth {
     private String password;
 
     @Column(name = "is_temp")
+    @Enumerated(EnumType.STRING)
     private IsTempPassword isTempPassword;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/project/team4backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/EmailVerification.java
@@ -20,8 +20,8 @@ public class EmailVerification {
     @Column(name = "email")
     private String email;
 
-    @Column(name = "code")
-    private String code;
+    @Column(name = "message")
+    private String message;
 
     @Column(name = "type")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/project/team4backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/EmailVerification.java
@@ -24,6 +24,7 @@ public class EmailVerification {
     private String code;
 
     @Column(name = "type")
+    @Enumerated(EnumType.STRING)
     private Type type;
 
     @Column(name = "created_at")

--- a/src/main/java/com/project/team4backend/domain/auth/exception/auth/AuthErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/auth/exception/auth/AuthErrorCode.java
@@ -9,10 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
 
-    _INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_400", "잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_402", "인증이 필요합니다"),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근이 금지되었습니다"),
-    _NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404","찾을 수 없습니다"),
+    AUTH_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_400_1", "잘못된 요청입니다."),
+    AUTH_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH400_2", "현재비밀번호와 새비밀번호가 같습니다."),
+    AUTH_WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "비밀번호가 일치하지 않습니다."),
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_402_2", "인증이 필요합니다"),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근이 금지되었습니다"),
+    AUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404","찾을 수 없습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/team4backend/domain/auth/exception/email/EmailVerificationErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/auth/exception/email/EmailVerificationErrorCode.java
@@ -9,10 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum EmailVerificationErrorCode implements BaseErrorCode {
 
-    _NOT_FOUND(HttpStatus.NOT_FOUND, "EmailVerification_404","이메일 정보를 찾을 수 없습니다"),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "EmailVerification_400_1", "인증 코드가 일치하지 않습니다."),
-    _EXPIRED(HttpStatus.BAD_REQUEST,"EmailVerification_400_2", "인증 코드가 만료되었습니다."),
-    _ALREADY_VERIFIED(HttpStatus.BAD_REQUEST,"EmailVerification_400_3", "이미 인증이 완료되었습니다.");
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "EmailVerification_404_1","이메일 정보를 찾을 수 없습니다"),
+    EMAIL_NOT_FOUND_CODE(HttpStatus.NOT_FOUND, "EmailVerification_404_2", "인증 코드가 존재하지 않습니다."),
+    EMAIL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "EmailVerification_400_1", "인증 코드가 일치하지 않습니다."),
+    EMAIL_EXPIRED(HttpStatus.BAD_REQUEST,"EmailVerification_400_2", "인증 코드가 만료되었습니다."),
+    EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST,"EmailVerification_400_3", "이미 인증이 완료되었습니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/team4backend/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/project/team4backend/domain/auth/repository/EmailVerificationRepository.java
@@ -1,6 +1,7 @@
 package com.project.team4backend.domain.auth.repository;
 
 import com.project.team4backend.domain.auth.entity.EmailVerification;
+import com.project.team4backend.domain.auth.entity.enums.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,5 +13,5 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
 
     int deleteByExpireAtBefore(LocalDateTime now);
 
-    Optional<EmailVerification> findTopByEmailOrderByCreatedAtDesc(String email);
+    Optional<EmailVerification> findTopByEmailAndTypeOrderByCreatedAtDesc(String email, Type type);
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
@@ -9,5 +9,9 @@ public interface AuthCommandService {
     //회원가입
     AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO, EmailVerification emailVerification);
 
+    //비밀번호 변경
+    void updatePassword(AuthReqDTO.UpdatePasswordReqDTO updatePasswordReqDTO, EmailVerification emailVerification);
+
+    //토큰 재발급
     AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto);
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
@@ -12,6 +12,9 @@ public interface AuthCommandService {
     //비밀번호 변경
     void updatePassword(AuthReqDTO.UpdatePasswordReqDTO updatePasswordReqDTO, EmailVerification emailVerification);
 
+    //임시비밀번호 발급
+    void updateTempPassword(AuthReqDTO.TempPasswordReqDTO tempPasswordReqDTO, EmailVerification emailVerification);
+
     //토큰 재발급
     AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto);
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandService.java
@@ -2,10 +2,12 @@ package com.project.team4backend.domain.auth.service.command.auth;
 
 import com.project.team4backend.domain.auth.dto.request.AuthReqDTO;
 import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
+import com.project.team4backend.domain.auth.entity.EmailVerification;
 
 public interface AuthCommandService {
 
-    AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO);
+    //회원가입
+    AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO, EmailVerification emailVerification);
 
     AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto);
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
@@ -70,7 +70,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
         String storedToken = refreshTokenService.getRefreshToken(email);
         if (storedToken == null || !storedToken.equals(refreshToken)) {
-            throw new AuthException(AuthErrorCode._INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
         //Refresh Token 이 유효한지 검사
         jwtUtil.validateToken(refreshToken);

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
@@ -9,6 +9,7 @@ import com.project.team4backend.domain.auth.entity.enums.IsTempPassword;
 import com.project.team4backend.domain.auth.exception.auth.AuthErrorCode;
 import com.project.team4backend.domain.auth.exception.auth.AuthException;
 import com.project.team4backend.domain.auth.repository.AuthRepository;
+import com.project.team4backend.domain.auth.service.command.email.EmailVerificationCommandService;
 import com.project.team4backend.domain.member.converter.MemberConverter;
 import com.project.team4backend.domain.member.entity.Member;
 import com.project.team4backend.domain.member.exception.MemberErrorCode;
@@ -24,6 +25,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
+import java.util.stream.Collectors;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -35,6 +39,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final SecurityConfig securityConfig;
     private final MemberRepository memberRepository;
     private final AuthRepository authRepository;
+    private final EmailVerificationCommandService emailVerificationCommandService;
 
     @Override
     public AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO, EmailVerification emailVerification) {
@@ -91,6 +96,26 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         // CHANGE_PASSWORD 타입의 emailVerfication 정보의 isVerified = true 설정 -> 이메일 인증 성공 최종 승인
         emailVerification.markAsVerified();
     }
+    @Override
+    public void updateTempPassword(AuthReqDTO.TempPasswordReqDTO tempPasswordReqDTO, EmailVerification emailVerification) {
+        Member member = memberRepository.findByEmail(emailVerification.getEmail())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Auth auth = authRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_NOT_FOUND));
+
+        String tempPassword = generateTempPassword();
+        String encodedPassword = null;
+        if (tempPassword != null) {
+            encodedPassword = securityConfig.passwordEncoder().encode(tempPassword);
+            auth.updatePassword(encodedPassword);
+        }
+        //저장된 임시 비밀번호 전송
+        emailVerificationCommandService.sendTempPassword(emailVerification.getEmail(), tempPassword);
+        //임시 비번임을 설정
+        auth.updateIsTempPassword(IsTempPassword.IS_TEMP_PASSWORD);
+        // TEMP_PASSWORD 타입의 emailVerfication 정보의 isVerified = true 설정 -> 이메일 인증 성공 최종 승인
+        emailVerification.markAsVerified();
+    }
 
     @Override
     public AuthResDTO.JwtResDTO reissueToken(AuthResDTO.JwtResDTO jwtDto) {
@@ -112,5 +137,15 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         log.info("[ Auth Service ] Refresh Token 이 유효합니다.");
 
         return jwtUtil.reissueToken(refreshToken);
+    }
+    //임시 비밀번호 발급용 메서드
+    private String generateTempPassword() {
+        String charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+
+        return random.ints(10, 0, charSet.length())
+                .mapToObj(charSet::charAt)
+                .map(String::valueOf)
+                .collect(Collectors.joining());
     }
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.project.team4backend.domain.auth.converter.AuthConverter;
 import com.project.team4backend.domain.auth.dto.request.AuthReqDTO;
 import com.project.team4backend.domain.auth.dto.response.AuthResDTO;
 import com.project.team4backend.domain.auth.entity.Auth;
+import com.project.team4backend.domain.auth.entity.EmailVerification;
 import com.project.team4backend.domain.auth.exception.auth.AuthErrorCode;
 import com.project.team4backend.domain.auth.exception.auth.AuthException;
 import com.project.team4backend.domain.auth.repository.AuthRepository;
@@ -34,7 +35,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final AuthRepository authRepository;
 
     @Override
-    public AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO) {
+    public AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO, EmailVerification emailVerification) {
         // Member 생성
         Member member = MemberConverter.toMember(signupReqDTO);
 
@@ -54,6 +55,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         Auth auth =  AuthConverter.toAuth(member, encodedPassword);
         // Auth 엔티티 저장
         authRepository.save(auth);
+
+        // SIGNUP 타입의 emailVerfication 정보의 isVerified = true 설정 -> 이메일 인증 성공 최종 승인
+        emailVerification.markAsVerified();
+
         // 응답 DTO로 변환 후 return
         return AuthConverter.toSignUpResDTO(member);
     }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandService.java
@@ -1,16 +1,18 @@
 package com.project.team4backend.domain.auth.service.command.email;
 
 import com.project.team4backend.domain.auth.dto.request.EmailVerificationReqDTO;
+import com.project.team4backend.domain.auth.entity.EmailVerification;
 
 public interface EmailVerificationCommandService {
     String createEmailVerification(EmailVerificationReqDTO.EmailSendReqDTO emailSendReqDTO);
 
-    void checkVerificationCode(EmailVerificationReqDTO.EmailVerifyReqDTO emailVerifyReqDTO);
+    EmailVerification checkVerificationCode(EmailVerificationReqDTO.EmailVerifyReqDTO emailVerifyReqDTO);
+
+    void emailVerificationAndMark(EmailVerificationReqDTO.EmailVerifyReqDTO emailVerifyReqDTO);
 
     void sendHtmlEmail(String to, String subject, String htmlContent);
 
     void sendTempPassword(String email);
 
     void sendVerificationCode(String email, String code);
-
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandService.java
@@ -12,7 +12,7 @@ public interface EmailVerificationCommandService {
 
     void sendHtmlEmail(String to, String subject, String htmlContent);
 
-    void sendTempPassword(String email);
+    void sendTempPassword(String email, String message);
 
-    void sendVerificationCode(String email, String code);
+    void sendVerificationCode(String email, String message);
 }

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
@@ -34,10 +34,10 @@ public class EmailVerificationCommandServiceImpl implements EmailVerificationCom
     //이메일인증 정보 생성
     @Override
     public String createEmailVerification(EmailVerificationReqDTO.EmailSendReqDTO emailSendReqDTO) {
-        String code = generateCode();
-        EmailVerification emailVerification = EmailVerificationConverter.toEmailVerification(emailSendReqDTO, code);
+        String message = generateCode();
+        EmailVerification emailVerification = EmailVerificationConverter.toEmailVerification(emailSendReqDTO, message);
         emailVerificationRepository.save(emailVerification);
-        return code;
+        return message;
     }
     //이메일 인증 코드 검증
     @Override
@@ -57,7 +57,7 @@ public class EmailVerificationCommandServiceImpl implements EmailVerificationCom
         }
 
         // 해당 코드 일치 여부 판단
-        if (!emailVerification.getCode().equals(emailVerifyReqDTO.authCode())) {
+        if (!emailVerification.getMessage().equals(emailVerifyReqDTO.authCode())) {
             throw new EmailVerificationException(EmailVerificationErrorCode.EMAIL_BAD_REQUEST);
         }
         return emailVerification;

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
@@ -88,15 +88,15 @@ public class EmailVerificationCommandServiceImpl implements EmailVerificationCom
 
     // 임시 비번 이메일로 전송
     @Override
-    public void sendTempPassword(String email) {
-        String html = emailTemplateBuilder.buildTempPasswordHtml(generateTempPassword());
-        sendHtmlEmail(email, "인증번호 안내", html);
+    public void sendTempPassword(String email, String message) {
+        String html = emailTemplateBuilder.buildTempPasswordHtml(message);
+        sendHtmlEmail(email, "임시 비밀번호 전송", html);
     }
 
     // 인증 코드 이메일로 전송
     @Override
-    public void sendVerificationCode(String email, String code) {
-        String html = emailTemplateBuilder.buildVerifyEmailHtml(code);
+    public void sendVerificationCode(String email, String message) {
+        String html = emailTemplateBuilder.buildVerifyEmailHtml(message);
         sendHtmlEmail(email, "인증 코드 전송", html);
     }
 
@@ -104,13 +104,6 @@ public class EmailVerificationCommandServiceImpl implements EmailVerificationCom
     private String generateCode() {
         Random random = new SecureRandom();
         return String.format("%06d", random.nextInt(1_000_000));
-    }
-    //임시 비밀번호 발급용 메서드
-    private String generateTempPassword() {
-        return new SecureRandom().ints(10, 33, 122)
-                .mapToObj(i -> (char) i)
-                .map(String::valueOf)
-                .collect(Collectors.joining());
     }
 }
 

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/email/EmailVerificationCommandServiceImpl.java
@@ -44,21 +44,21 @@ public class EmailVerificationCommandServiceImpl implements EmailVerificationCom
     public EmailVerification checkVerificationCode(EmailVerificationReqDTO.EmailVerifyReqDTO emailVerifyReqDTO) {
         EmailVerification emailVerification = emailVerificationRepository
                 .findTopByEmailAndTypeOrderByCreatedAtDesc(emailVerifyReqDTO.email(), emailVerifyReqDTO.type())
-                .orElseThrow(() -> new EmailVerificationException(EmailVerificationErrorCode._NOT_FOUND));
+                .orElseThrow(() -> new EmailVerificationException(EmailVerificationErrorCode.EMAIL_NOT_FOUND));
 
         // 인증 완료 여부 판단 - 이메일이 동일해서 가져왔는데 인증 되어있을 수 있기 때문이다.
         if (emailVerification.getIsVerified()) {
-            throw new EmailVerificationException(EmailVerificationErrorCode._ALREADY_VERIFIED);
+            throw new EmailVerificationException(EmailVerificationErrorCode.EMAIL_ALREADY_VERIFIED);
         }
 
         // 해당 코드 만료 여부 판단
         if (emailVerification.getExpireAt().isBefore(LocalDateTime.now())) {
-            throw new EmailVerificationException(EmailVerificationErrorCode._EXPIRED);
+            throw new EmailVerificationException(EmailVerificationErrorCode.EMAIL_EXPIRED);
         }
 
         // 해당 코드 일치 여부 판단
         if (!emailVerification.getCode().equals(emailVerifyReqDTO.authCode())) {
-            throw new EmailVerificationException(EmailVerificationErrorCode._BAD_REQUEST);
+            throw new EmailVerificationException(EmailVerificationErrorCode.EMAIL_BAD_REQUEST);
         }
         return emailVerification;
     }

--- a/src/main/java/com/project/team4backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/member/exception/MemberErrorCode.java
@@ -11,8 +11,6 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다."),
     MEMBER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "MEMBER409_1", "이미 사용 중인 이메일입니다."),
-    MEMBER_WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER401_1", "비밀번호가 일치하지 않습니다."),
-    MEMBER_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER400_1", "현재비밀번호와 새비밀번호가 같습니다."),
     MEMBER_WRONG_VALUE(HttpStatus.BAD_REQUEST, "MEMBER401_2", "잘못된 값을 입력했습니다."),
     ;
 

--- a/src/main/java/com/project/team4backend/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/CustomLoginFilter.java
@@ -44,7 +44,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         try {
             requestBody = objectMapper.readValue(request.getInputStream(), AuthReqDTO.LoginReqDTO.class);
         } catch (IOException e) {
-            throw new AuthException(AuthErrorCode._NOT_FOUND);
+            throw new AuthException(AuthErrorCode.AUTH_NOT_FOUND);
         }
 
         //Request Body 에서 추출

--- a/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
@@ -43,8 +43,8 @@ public class ForcePasswordChangeFilter extends OncePerRequestFilter {
                 boolean isAllowed = ALLOWED_PATHS.stream().anyMatch(requestURI::startsWith);
                 if (!isAllowed) {
                     log.warn("[ ForcePasswordChangeFilter ] 임시 비밀번호 상태로 허용되지 않은 경로 접근 시도");
-                    String errorCode = AuthErrorCode._FORBIDDEN.getCode();
-                    String errorMessage = AuthErrorCode._FORBIDDEN.getMessage();
+                    String errorCode = AuthErrorCode.AUTH_FORBIDDEN.getCode();
+                    String errorMessage = AuthErrorCode.AUTH_FORBIDDEN.getMessage();
 
                     CustomResponse<String> responseBody = CustomResponse.onFailure(errorCode, errorMessage);
 

--- a/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
+++ b/src/main/java/com/project/team4backend/global/security/filter/ForcePasswordChangeFilter.java
@@ -25,7 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ForcePasswordChangeFilter extends OncePerRequestFilter {
     private static final List<String> ALLOWED_PATHS = List.of(
-            "/api/v1/auths/password-reset", "/api/v1/auths/reissue"
+            "/api/v1/auths/reset-password", "/api/v1/auths/reissue", "/api/v1/auths/emailVerifications/send"
     );
 
     @Override

--- a/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
@@ -49,7 +49,7 @@ public class CustomLogoutHandler implements LogoutHandler {
                 refreshTokenService.deleteRefreshToken(email);
                 log.info("[LogoutHandler] Redis에서 Refresh Token 삭제 완료");
             } else  // 토큰이 없으면 로그인을 하지 않은 상태이므로 인증 필요 예외 처리
-                throw new AuthException(AuthErrorCode._UNAUTHORIZED);
+                throw new AuthException(AuthErrorCode.AUTH_UNAUTHORIZED);
 
         SecurityContextHolder.clearContext();
     }

--- a/src/main/java/com/project/team4backend/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/JwtAccessDeniedHandler.java
@@ -18,8 +18,8 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(403);
         CustomResponse<Object> errorResponse = CustomResponse.onFailure(
-                AuthErrorCode._FORBIDDEN.getCode(),
-                AuthErrorCode._FORBIDDEN.getMessage(),
+                AuthErrorCode.AUTH_FORBIDDEN.getCode(),
+                AuthErrorCode.AUTH_FORBIDDEN.getMessage(),
                 null
         );
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/com/project/team4backend/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -19,8 +19,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(401);
         CustomResponse<Object> errorResponse = CustomResponse.onFailure(
-                AuthErrorCode._UNAUTHORIZED.getCode(),
-                AuthErrorCode._UNAUTHORIZED.getMessage(),
+                AuthErrorCode.AUTH_UNAUTHORIZED.getCode(),
+                AuthErrorCode.AUTH_UNAUTHORIZED.getMessage(),
                 null
         );
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
# ☝️Issue Number

- #22 

##  📌 개요

- 비밀번호 변경 api
- 임시비밀번호 발급 api
- 임시비밀번호 발급 시, 접근 가능한 url 추가 (임시 비밀번호는 보안에 취약하기에 바로 변경하도록 리다이렉트해야함)

## 🔁 변경 사항

- 기존에 이메일인증 도메인에 code 필드에 인증 코드와 임시 비밀번호가 들어가다보니 code라는 단어보다는 message가 의미가 더 맞을 거같아서 message로 수정했습니다!
- 
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점