### PR TITLE
Feat/#15 s3 bucket 생성 이미지 업로드 삭제 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    // S3
+    implementation 'software.amazon.awssdk:s3:2.20.68'
 }
 
 jar {

--- a/src/main/java/com/project/team4backend/Team4BackEndApplication.java
+++ b/src/main/java/com/project/team4backend/Team4BackEndApplication.java
@@ -3,9 +3,11 @@ package com.project.team4backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing //JPA Auditing 기능 활성화
+@EnableScheduling // 스케쥴러 기능 활성화
 public class Team4BackEndApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
+++ b/src/main/java/com/project/team4backend/domain/auth/contoller/EmailVerificationController.java
@@ -28,12 +28,12 @@ public class EmailVerificationController {
     public CustomResponse<String> SendEmailVerificationCode(@RequestBody EmailVerificationReqDTO.EmailSendReqDTO emailSendReqDTO) {
         switch (emailSendReqDTO.type()) {
             case SIGNUP -> {
-                if (memberRepository.existsByEmail(emailSendReqDTO.email())) {
+                if (memberRepository.existsByEmailAndIsDeletedFalse(emailSendReqDTO.email())) {
                     throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
                 }
             }
             case TEMP_PASSWORD, CHANGE_PASSWORD -> {
-                if (!memberRepository.existsByEmail(emailSendReqDTO.email())) {
+                if (!memberRepository.existsByEmailAndIsDeletedFalse(emailSendReqDTO.email())) {
                     throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
                 }
             }

--- a/src/main/java/com/project/team4backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/RefreshTokenService.java
@@ -1,16 +1,21 @@
 package com.project.team4backend.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
 @Service
-@RequiredArgsConstructor
 public class RefreshTokenService {
 
+    @Qualifier("tokenRedisTemplate")
     private final RedisTemplate<String, String> redisTemplate;
+
+    public RefreshTokenService(@Qualifier("tokenRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
 
     private static final Duration REFRESH_TOKEN_EXPIRATION = Duration.ofDays(1); // 1일
 

--- a/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/command/auth/AuthCommandServiceImpl.java
@@ -43,15 +43,15 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     public AuthResDTO.SignUpResDTO signUp(AuthReqDTO.SignupReqDTO signupReqDTO, EmailVerification emailVerification) {
+        if (memberRepository.existsByEmailAndIsDeletedFalse(signupReqDTO.email())) {
+            throw new CustomException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
+        }
+
         // Member 생성
         Member member = MemberConverter.toMember(signupReqDTO);
 
-        // Member 엔티티 DB에 저장
-        try {
-            memberRepository.save(member);
-        } catch (DataIntegrityViolationException e) {
-            throw new CustomException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
-        }
+        // Member 저장
+        memberRepository.save(member);
 
         String password = signupReqDTO.password();
         String encodedPassword = null;

--- a/src/main/java/com/project/team4backend/domain/auth/service/scheduler/EmailVerificationScheduler.java
+++ b/src/main/java/com/project/team4backend/domain/auth/service/scheduler/EmailVerificationScheduler.java
@@ -5,11 +5,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Component
 public class EmailVerificationScheduler {
 

--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -42,5 +42,11 @@ public class ImageConverter {
                 .build();
     }
 
+    public static ImageResDTO.SaveImageResDTO toSaveImageResDTO(String imageUrl) {
+        return ImageResDTO.SaveImageResDTO.builder()
+                .profileImageUrl(imageUrl)
+                .message("이미지 업로드 완료되었습니다.")
+                .build();
+    }
 
 }

--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.Duration;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -23,7 +23,7 @@ public class ImageConverter {
     public static ImageInternelDTO.ImageTrackingResDTO toImageTrackingResDTO(String fileKey) {
         return ImageInternelDTO.ImageTrackingResDTO.builder()
                 .fileKey(fileKey)
-                .createAt(LocalDate.now())
+                .createAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -1,9 +1,46 @@
 package com.project.team4backend.domain.image.converter;
 
+import com.project.team4backend.domain.image.dto.internel.ImageInternelDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageConverter {
+    public static ImageResDTO.PresignedUrlResDTO toPresignedUrlResDTO(String presignedUrl, String fileKey) {
+        return ImageResDTO.PresignedUrlResDTO.builder()
+                .presignedUrl(presignedUrl)
+                .fileKey(fileKey)
+                .build();
+    }
+
+    public static ImageInternelDTO.ImageTrackingResDTO toImageTrackingResDTO(String fileKey) {
+        return ImageInternelDTO.ImageTrackingResDTO.builder()
+                .fileKey(fileKey)
+                .createAt(LocalDate.now())
+                .build();
+    }
+
+    public static PutObjectRequest toPutObjectRequest(String bucketName, String fileKey, String contentType) {
+        return PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .contentType(contentType)
+                .build();
+    }
+
+    public static PutObjectPresignRequest toPutObjectPresignRequest(Duration presignedUrlDurationMinutes, PutObjectRequest putObjectRequest) {
+        return PutObjectPresignRequest.builder()
+                .signatureDuration(presignedUrlDurationMinutes)
+                .putObjectRequest(putObjectRequest)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -1,0 +1,9 @@
+package com.project.team4backend.domain.image.converter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageConverter {
+
+}

--- a/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
@@ -2,12 +2,12 @@ package com.project.team4backend.domain.image.dto.internel;
 
 import lombok.Builder;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class ImageInternelDTO {
     @Builder
     public record ImageTrackingResDTO (
             String fileKey,
-            LocalDate createAt
+            LocalDateTime createAt
     ){}
 }

--- a/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
@@ -1,0 +1,13 @@
+package com.project.team4backend.domain.image.dto.internel;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+public class ImageInternelDTO {
+    @Builder
+    public record ImageTrackingResDTO (
+            String fileKey,
+            LocalDate createAt
+    ){}
+}

--- a/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
@@ -1,0 +1,17 @@
+package com.project.team4backend.domain.image.dto.request;
+
+import lombok.Builder;
+
+public class ImageReqDTO {
+    @Builder
+    public record PresignedUrlDTO(
+            String fileExtension,
+            String contentType
+    ) {
+    }
+    @Builder
+    public record SaveImageReqDTO(
+            String profileImageUrl
+    ){
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/image/dto/response/ImageResDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/response/ImageResDTO.java
@@ -1,0 +1,21 @@
+package com.project.team4backend.domain.image.dto.response;
+
+
+import lombok.Builder;
+
+
+public class ImageResDTO {
+    @Builder
+    public record PresignedUrlResDTO (
+            String presignedUrl,
+            String fileKey
+    ){
+    }
+
+    @Builder
+    public record SaveImageResDTO (
+            String profileImageUrl,
+            String message
+    ){
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
@@ -10,10 +10,17 @@ import org.springframework.http.HttpStatus;
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "IMAGE_400_1", "지원하지 않는 파일 확장자입니다."),
     IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE_400_2", "지원하지 않는 콘텐츠 타입입니다."),
+    IMAGE_KEY_MISSING(HttpStatus.BAD_REQUEST, "IMAGE_400_3","이미지 키가 누락되었습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_404_1", "S3에 이미지를 찾을 수 없습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_1", "이미지 업로드에 실패했습니다."),
     IMAGE_COMMIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_2", "이미지 커밋에 실패했습니다."),
-    IMAGE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_3", "이미지 삭제에 실패했습니다.");
+    IMAGE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_3", "이미지 삭제에 실패했습니다."),
+    REDIS_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_4", "Redis에 이미지 추적 정보를 저장하는 데 실패했습니다."),
+    REDIS_REMOVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_5", "Redis에서 이미지 추적 정보를 제거하는 데 실패했습니다."),
+    REDIS_KEY_FETCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_6", "Redis에서 이미지 추적 키 목록을 조회하는 데 실패했습니다."),
+    REDIS_EXPIRED_FETCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_7", "Redis에서 만료된 이미지 키를 조회하는 데 실패했습니다.")
+    ;
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
@@ -1,0 +1,21 @@
+package com.project.team4backend.domain.image.exception;
+
+import com.project.team4backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorCode implements BaseErrorCode {
+    IMAGE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "IMAGE_400_1", "지원하지 않는 파일 확장자입니다."),
+    IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE_400_2", "지원하지 않는 콘텐츠 타입입니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_404_1", "S3에 이미지를 찾을 수 없습니다."),
+    IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_1", "이미지 업로드에 실패했습니다."),
+    IMAGE_COMMIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_2", "이미지 커밋에 실패했습니다."),
+    IMAGE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_3", "이미지 삭제에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/team4backend/domain/image/exception/ImageException.java
+++ b/src/main/java/com/project/team4backend/domain/image/exception/ImageException.java
@@ -1,0 +1,12 @@
+package com.project.team4backend.domain.image.exception;
+
+
+import com.project.team4backend.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class ImageException extends CustomException {
+    public ImageException(ImageErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/image/service/RedisImageTracker.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/RedisImageTracker.java
@@ -91,9 +91,9 @@ public class RedisImageTracker {
 
                             ImageInternelDTO.ImageTrackingResDTO info = objectMapper.convertValue(raw, ImageInternelDTO.ImageTrackingResDTO.class);
 
-                            return info != null && info.createAt().isBefore(ChronoLocalDate.from(expiredBefore));
+                            return info != null && info.createAt().isBefore(expiredBefore);
                         } catch (Exception e) {
-                            log.warn("Error checking expiration for fileKey: {}", fileKey, e);
+                            log.warn("fileKey 만료 확인 중 에러 발생: {}", fileKey, e);
                             return false;
                         }
                     })

--- a/src/main/java/com/project/team4backend/domain/image/service/RedisImageTracker.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/RedisImageTracker.java
@@ -1,0 +1,106 @@
+package com.project.team4backend.domain.image.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.team4backend.domain.image.converter.ImageConverter;
+import com.project.team4backend.domain.image.dto.internel.ImageInternelDTO;
+import com.project.team4backend.domain.image.exception.ImageErrorCode;
+import com.project.team4backend.domain.image.exception.ImageException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDate;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+public class RedisImageTracker {
+
+    private final RedisTemplate<String, Object> imageRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 생성자에서 @Qualifier로 imageRedisTemplate 주입
+    public RedisImageTracker(
+            @Qualifier("imageRedisTemplate") RedisTemplate<String, Object> imageRedisTemplate,
+            ObjectMapper objectMapper
+    ) {
+        this.imageRedisTemplate = imageRedisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    private static final String REDIS_KEY_PREFIX = "images:";
+    private static final long TRACKING_DURATION_HOURS = 24; // 24시간 추적
+
+    /**
+     * Redis에 이미지 추적 정보 저장
+     */
+    public void save(String fileKey) {
+        try {
+            String redisKey = REDIS_KEY_PREFIX + fileKey;
+            ImageInternelDTO.ImageTrackingResDTO imageTrackingResDTO = ImageConverter.toImageTrackingResDTO(fileKey);
+
+            imageRedisTemplate.opsForValue().set(redisKey, imageTrackingResDTO, TRACKING_DURATION_HOURS, TimeUnit.HOURS);
+
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_SAVE_FAIL);
+        }
+    }
+
+    /**
+     * Redis에서 이미지 추적 정보 제거
+     */
+    public void remove(String fileKey) {
+        try {
+            String redisKey = REDIS_KEY_PREFIX + fileKey;
+            imageRedisTemplate.delete(redisKey);
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_REMOVE_FAIL);
+        }
+    }
+
+    /**
+     * 모든 추적 중인 이미지 키 조회
+     */
+    public Set<String> getAllTrackedFileKeys() {
+        try {
+            Set<String> redisKeys = imageRedisTemplate.keys(REDIS_KEY_PREFIX + "*");
+            return redisKeys.stream()
+                    .map(key -> key.substring(REDIS_KEY_PREFIX.length()))
+                    .collect(java.util.stream.Collectors.toSet());
+
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
+        }
+    }
+
+    /**
+     * 특정 시간 이전의 추적 정보 조회
+     */
+    public Set<String> getExpiredFileKeys(LocalDateTime expiredBefore) {
+        try {
+            Set<String> allKeys = getAllTrackedFileKeys();
+            return allKeys.stream()
+                    .filter(fileKey -> {
+                        try {
+                            String redisKey = REDIS_KEY_PREFIX + fileKey;
+                            Object raw = imageRedisTemplate.opsForValue().get(redisKey);
+                            if (raw == null) return false;
+
+                            ImageInternelDTO.ImageTrackingResDTO info = objectMapper.convertValue(raw, ImageInternelDTO.ImageTrackingResDTO.class);
+
+                            return info != null && info.createAt().isBefore(ChronoLocalDate.from(expiredBefore));
+                        } catch (Exception e) {
+                            log.warn("Error checking expiration for fileKey: {}", fileKey, e);
+                            return false;
+                        }
+                    })
+                    .collect(java.util.stream.Collectors.toSet());
+
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_EXPIRED_FETCH_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -1,0 +1,5 @@
+package com.project.team4backend.domain.image.service.command;
+
+public interface ImageCommandService {
+
+}

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -6,4 +6,8 @@ import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 public interface ImageCommandService {
     ImageResDTO.PresignedUrlResDTO generatePresignedUrl(ImageReqDTO.PresignedUrlDTO presignedUrl);
 
+    String commit(String fileKey);
+
+    void delete(String fileKey);
+
 }

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -1,5 +1,9 @@
 package com.project.team4backend.domain.image.service.command;
 
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
+
 public interface ImageCommandService {
+    ImageResDTO.PresignedUrlResDTO generatePresignedUrl(ImageReqDTO.PresignedUrlDTO presignedUrl);
 
 }

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
@@ -1,0 +1,14 @@
+package com.project.team4backend.domain.image.service.command;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ImageCommandServiceImpl implements ImageCommandService {
+}

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
@@ -1,14 +1,139 @@
 package com.project.team4backend.domain.image.service.command;
 
-
+import com.project.team4backend.domain.image.converter.ImageConverter;
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
+import com.project.team4backend.domain.image.exception.ImageErrorCode;
+import com.project.team4backend.domain.image.exception.ImageException;
+import com.project.team4backend.domain.image.service.RedisImageTracker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.Duration;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 @Transactional
 public class ImageCommandServiceImpl implements ImageCommandService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final RedisImageTracker redisImageTracker;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${aws.s3.presigned-url-duration:15}")
+    private long presignedUrlDurationMinutes;
+
+    @Value(("${aws.s3.region}"))
+    private String region;
+
+    /**
+     * Presigned URL 발급
+     * @param "fileExtension" 파일 확장자 (예: jpg, png)
+     * @param "contentType" MIME 타입 (예: image/jpeg)
+     * @return Presigned URL과 파일 키
+     */
+    @Override
+    public ImageResDTO.PresignedUrlResDTO generatePresignedUrl(ImageReqDTO.PresignedUrlDTO presignedUrlDTO) {
+        validateFileExtension(presignedUrlDTO.fileExtension());
+        validateContentType(presignedUrlDTO.contentType());
+
+        String fileKey = generateFileKey(presignedUrlDTO.fileExtension());
+
+        try {
+            PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucketName, fileKey, presignedUrlDTO.contentType());
+
+            PutObjectPresignRequest presignRequest = ImageConverter.toPutObjectPresignRequest(Duration.ofMinutes(presignedUrlDurationMinutes), putObjectRequest);
+
+            PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+            String presignedUrl = presignedRequest.url().toString();
+
+            // Redis에 추적 정보 저장
+            redisImageTracker.save(fileKey);
+
+            return ImageConverter.toPresignedUrlResDTO(presignedUrl,fileKey);
+
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+    }
+    /**
+     * 파일 존재 여부 확인
+     */
+    private boolean isFileExists(String fileKey) {
+        try {
+            HeadObjectRequest headRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileKey)
+                    .build();
+
+            s3Client.headObject(headRequest);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
+        }
+    }
+
+    /**
+     * 파일 키 생성
+     */
+    private String generateFileKey(String fileExtension) {
+        String uuid = UUID.randomUUID().toString();
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        return String.format("images/%s_%s.%s", timestamp, uuid, fileExtension);
+    }
+
+    /**
+     * 파일 확장자 검증
+     */
+    private void validateFileExtension(String fileExtension) {
+        if (fileExtension == null || fileExtension.trim().isEmpty()) {
+            throw new ImageException(ImageErrorCode.IMAGE_INVALID_EXTENSION);
+        }
+
+        String[] allowedExtensions = {"jpg", "jpeg", "png", "gif", "webp"};
+        String lowerExtension = fileExtension.toLowerCase();
+
+        for (String allowed : allowedExtensions) {
+            if (allowed.equals(lowerExtension)) {
+                return;
+            }
+        }
+
+        throw new ImageException(ImageErrorCode.IMAGE_INVALID_CONTENT_TYPE);
+    }
+
+    /**
+     * Content Type 검증
+     */
+    private void validateContentType(String contentType) {
+        if (contentType == null || contentType.trim().isEmpty()) {
+            throw new ImageException(ImageErrorCode.IMAGE_INVALID_CONTENT_TYPE);
+        }
+
+        String[] allowedTypes = {"image/jpeg", "image/png", "image/gif", "image/webp"};
+
+        for (String allowed : allowedTypes) {
+            if (allowed.equals(contentType)) {
+                return;
+            }
+        }
+
+        throw new ImageException(ImageErrorCode.IMAGE_INVALID_CONTENT_TYPE);
+    }
 }

--- a/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
@@ -1,0 +1,63 @@
+package com.project.team4backend.domain.image.service.scheduler;
+import com.project.team4backend.domain.image.exception.ImageErrorCode;
+import com.project.team4backend.domain.image.exception.ImageException;
+import com.project.team4backend.domain.image.service.RedisImageTracker;
+import com.project.team4backend.domain.image.service.command.ImageCommandService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageScheduler {
+
+    private final ImageCommandService imageCommandService;
+    private final RedisImageTracker redisImageTracker;
+
+    /**
+     * 매 시간마다 미사용 이미지 정리
+     */
+    @Scheduled(cron = "0 0 * * * *") // 매 시간 0분에 실행
+    public void run() {
+        log.info("이미지 fileKey 스케줄러 작동");
+
+        try {
+            // 1시간 전 이전에 생성된 추적 정보 조회
+            LocalDateTime expiredBefore = LocalDateTime.now().minusHours(1);
+            Set<String> expiredFileKeys = redisImageTracker.getExpiredFileKeys(expiredBefore);
+
+            if (expiredFileKeys.isEmpty()) {
+                log.info("정리할 FileKey가 없습니다.");
+                return;
+            }
+
+            log.info("총 {}개의 만료 이미지 정리 시도", expiredFileKeys.size());
+
+            int deletedCount = 0;
+            int errorCount = 0;
+
+            for (String fileKey : expiredFileKeys) {
+                try {
+                    imageCommandService.delete(fileKey);
+                    deletedCount++;
+                } catch (Exception e) {
+                    log.error("만료 이미지 삭제 실패: {}", fileKey, e);
+                    errorCount++;
+                }
+            }
+
+            log.info("이미시 삭제 완료 - 삭제: {}, 에러: {}", deletedCount, errorCount);
+
+        } catch (Exception e) {
+            log.error("만료 이미지 키 조회 실패", e);
+            throw new ImageException(ImageErrorCode.REDIS_EXPIRED_FETCH_FAIL);
+
+        }
+    }
+}
+

--- a/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
@@ -36,7 +36,7 @@ public class ImageScheduler {
                 return;
             }
 
-            log.info("총 {}개의 만료 이미지 정리 시도", expiredFileKeys.size());
+            log.info("총 {}개의 만료 FileKey 정리 시도", expiredFileKeys.size());
 
             int deletedCount = 0;
             int errorCount = 0;
@@ -46,15 +46,15 @@ public class ImageScheduler {
                     imageCommandService.delete(fileKey);
                     deletedCount++;
                 } catch (Exception e) {
-                    log.error("만료 이미지 삭제 실패: {}", fileKey, e);
+                    log.error("만료 FileKey 삭제 실패: {}", fileKey, e);
                     errorCount++;
                 }
             }
 
-            log.info("이미시 삭제 완료 - 삭제: {}, 에러: {}", deletedCount, errorCount);
+            log.info("FileKey 삭제 완료 - 삭제: {}, 에러: {}", deletedCount, errorCount);
 
         } catch (Exception e) {
-            log.error("만료 이미지 키 조회 실패", e);
+            log.error("만료 FileKey 조회 실패", e);
             throw new ImageException(ImageErrorCode.REDIS_EXPIRED_FETCH_FAIL);
 
         }

--- a/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
+++ b/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
@@ -89,4 +89,13 @@ public class MemberController {
         return CustomResponse.onSuccess("회원정보가 삭제되었습니다.");
     }
 
+    @Operation(method = "DELETE", summary = "프로필 이미지 삭제", description = "프로필 이미지 삭제 api입니다.")
+    @DeleteMapping("/profile-image")
+    public CustomResponse<String> deleteProfileImage(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        memberCommandService.deleteProfileImage(customUserDetails.getEmail());
+        return CustomResponse.onSuccess("프로필 이미지가 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
+++ b/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
@@ -21,6 +21,27 @@ public class MemberController {
 
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
+    private final ImageCommandService imageCommandService;
+    private final MemberRepository memberRepository;
+
+    @Operation(method = "POST", summary = "프로필 이미지 업로드1", description = "프로필 이미지 선택 api, 업로드 하는건 아님")
+    @PostMapping("/profile-image1")
+    public CustomResponse<ImageResDTO.PresignedUrlResDTO> uploadProfileImages
+            (@AuthenticationPrincipal CustomUserDetails customUserDetails,
+             @RequestBody ImageReqDTO.PresignedUrlDTO presignedUrlDTO) {
+        ImageResDTO.PresignedUrlResDTO presignedUrlResDTO = imageCommandService.generatePresignedUrl(presignedUrlDTO); // presignedUrl 발급
+
+        memberCommandService.selectProfileImage(customUserDetails.getEmail(), presignedUrlResDTO.fileKey()); // member의 profileImageKey에 fileKey 저장
+        return CustomResponse.onSuccess(presignedUrlResDTO);
+    }
+
+    @Operation(method = "GET", summary = "회원 정보 조회", description = "회원 정보 조회 api입니다.")
+    @GetMapping
+    public CustomResponse<MemberResDTO.MemberPreviewResDTO> getMember(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        return CustomResponse.onSuccess(memberQueryService.getMemberPreview(customUserDetails.getEmail()));
+    }
 
     @Operation(method = "PATCH", summary = "계정 정보 수정", description = "회원 정보 수정 api입니다.")
     @PatchMapping("/body")
@@ -38,15 +59,6 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         return CustomResponse.onSuccess(memberCommandService.updateMemberBody(customUserDetails.getEmail(), memberBodyUpdateReqDTO));
-    }
-
-
-    @Operation(method = "GET", summary = "회원 정보 조회", description = "회원 정보 조회 api입니다.")
-    @GetMapping
-    public CustomResponse<MemberResDTO.MemberPreviewResDTO> getMember(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
-    ) {
-        return CustomResponse.onSuccess(memberQueryService.getMemberPreview(customUserDetails.getEmail()));
     }
 
     @Operation(method = "DELETE", summary = "회원 탈퇴", description = "회원 탈퇴 작동 시 해당 유저의 is_deleted = true로 바뀜")

--- a/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
+++ b/src/main/java/com/project/team4backend/domain/member/contoller/MemberController.java
@@ -1,7 +1,14 @@
 package com.project.team4backend.domain.member.contoller;
 
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
+import com.project.team4backend.domain.image.service.command.ImageCommandService;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
 import com.project.team4backend.domain.member.dto.response.MemberResDTO;
+import com.project.team4backend.domain.member.entity.Member;
+import com.project.team4backend.domain.member.exception.MemberErrorCode;
+import com.project.team4backend.domain.member.exception.MemberException;
+import com.project.team4backend.domain.member.repository.MemberRepository;
 import com.project.team4backend.domain.member.service.command.MemberCommandService;
 import com.project.team4backend.domain.member.service.query.MemberQueryService;
 import com.project.team4backend.global.apiPayload.CustomResponse;
@@ -33,6 +40,18 @@ public class MemberController {
 
         memberCommandService.selectProfileImage(customUserDetails.getEmail(), presignedUrlResDTO.fileKey()); // member의 profileImageKey에 fileKey 저장
         return CustomResponse.onSuccess(presignedUrlResDTO);
+    }
+
+    @Operation(method = "POST", summary = "프로필 이미지 업로드2", description = "선택한 프로필 이미지 저장 api, 이때 업로드")
+    @PostMapping("/profile-image2")
+    public CustomResponse<ImageResDTO.SaveImageResDTO> saveProfileImages(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody ImageReqDTO.SaveImageReqDTO saveImageReqDTO) {
+
+        Member member = memberRepository.findByEmail(customUserDetails.getEmail())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        String fileKey = member.getProfileImageKey();
+        return CustomResponse.onSuccess(memberCommandService.saveProfileImage(member, fileKey, imageCommandService.commit(fileKey), saveImageReqDTO));
     }
 
     @Operation(method = "GET", summary = "회원 정보 조회", description = "회원 정보 조회 api입니다.")

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -48,6 +48,12 @@ public class Member extends BaseEntity {
         this.profileImageUrl = ImageUrl;
     }
 
+    public void deleteProfileImage() {
+        this.profileImageUrl = null;
+        this.profileImageKey = null;
+    }
+
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -45,7 +45,7 @@ public class Member extends BaseEntity {
     }
 
     public void saveImage(String ImageUrl) {
-        this.profileImageKey = ImageUrl;
+        this.profileImageUrl = ImageUrl;
     }
 
     @Id

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -44,6 +44,10 @@ public class Member extends BaseEntity {
         this.profileImageKey = fileKey;
     }
 
+    public void saveImage(String ImageUrl) {
+        this.profileImageKey = ImageUrl;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -40,6 +40,10 @@ public class Member extends BaseEntity {
         this.isDeleted = true;
     }
 
+    public void selectImage(String fileKey) {
+        this.profileImageKey = fileKey;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -65,6 +69,9 @@ public class Member extends BaseEntity {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @Column(name = "profile_image_key")
+    private String profileImageKey;
 
     @Column(name = "role")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/project/team4backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/team4backend/domain/member/repository/MemberRepository.java
@@ -13,5 +13,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     @Query("SELECT m FROM Member m WHERE m.email = :email and m.isDeleted = false")
     Optional<Member> findByEmail(@Param("email") String email);
 
-    Boolean existsByEmail(String email);
+    @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email AND m.isDeleted = false")
+    Boolean existsByEmailAndIsDeletedFalse(@Param("email") String email);
 }

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
@@ -3,6 +3,8 @@ package com.project.team4backend.domain.member.service.command;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
 
 public interface MemberCommandService {
+    void selectProfileImage(String email, String fileKey);
+
     String updateMemberAccount(String email, MemberReqDTO.MemberAccountUpdateReqDTO memberAccountUpdateReqDTO);
 
     String updateMemberBody(String email, MemberReqDTO.MemberBodyUpdateReqDTO memberBodyUpdateReqDTO);

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
@@ -1,9 +1,14 @@
 package com.project.team4backend.domain.member.service.command;
 
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
+import com.project.team4backend.domain.member.entity.Member;
 
 public interface MemberCommandService {
     void selectProfileImage(String email, String fileKey);
+
+    ImageResDTO.SaveImageResDTO saveProfileImage(Member member, String fileKey, String ImageUrl, ImageReqDTO.SaveImageReqDTO saveImageReqDTO);
 
     String updateMemberAccount(String email, MemberReqDTO.MemberAccountUpdateReqDTO memberAccountUpdateReqDTO);
 

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
@@ -15,4 +15,6 @@ public interface MemberCommandService {
     String updateMemberBody(String email, MemberReqDTO.MemberBodyUpdateReqDTO memberBodyUpdateReqDTO);
 
     void deleteMember(String email);
+
+    void deleteProfileImage(String email);
 }

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
@@ -14,8 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -24,6 +22,15 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final AuthRepository authRepository;
+
+    //프로필 이미지 업로드1(이미지 선택)
+    @Override
+    public void selectProfileImage(String email, String fileKey){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(()-> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.selectImage(fileKey);
+    }
 
     // 계정 정보 수정
     @Override

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.project.team4backend.domain.auth.repository.AuthRepository;
 import com.project.team4backend.domain.image.converter.ImageConverter;
 import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team4backend.domain.image.dto.response.ImageResDTO;
+import com.project.team4backend.domain.image.service.command.ImageCommandService;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
 import com.project.team4backend.domain.member.entity.Member;
 import com.project.team4backend.domain.member.exception.MemberErrorCode;
@@ -25,6 +26,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final AuthRepository authRepository;
+
+    private final ImageCommandService imageCommandService;
 
     //프로필 이미지 업로드1(이미지 선택)
     @Override
@@ -72,5 +75,16 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         member.deleteMember();
         auth.deleteAuth();
+    }
+    @Override
+    public void deleteProfileImage(String email){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(()-> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        String fileKey = member.getProfileImageKey();
+
+        imageCommandService.delete(fileKey);
+
+        member.deleteProfileImage();
     }
 }

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandServiceImpl.java
@@ -4,6 +4,9 @@ import com.project.team4backend.domain.auth.entity.Auth;
 import com.project.team4backend.domain.auth.exception.auth.AuthErrorCode;
 import com.project.team4backend.domain.auth.exception.auth.AuthException;
 import com.project.team4backend.domain.auth.repository.AuthRepository;
+import com.project.team4backend.domain.image.converter.ImageConverter;
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
 import com.project.team4backend.domain.member.entity.Member;
 import com.project.team4backend.domain.member.exception.MemberErrorCode;
@@ -30,6 +33,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(()-> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.selectImage(fileKey);
+    }
+
+    //프로필 이미지 업로드2(이미지 저장)
+    @Override
+    public ImageResDTO.SaveImageResDTO saveProfileImage(Member member, String fileKey, String imageUrl, ImageReqDTO.SaveImageReqDTO saveImageReqDTO){
+        member.saveImage(imageUrl);
+        return ImageConverter.toSaveImageResDTO(imageUrl);
     }
 
     // 계정 정보 수정

--- a/src/main/java/com/project/team4backend/global/security/Config/RedisConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/RedisConfig.java
@@ -1,21 +1,43 @@
 package com.project.team4backend.global.security.Config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 
 @Configuration
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    public RedisTemplate<String, String> tokenRedisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+    @Bean
+    public RedisTemplate<String, Object> imageRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDateTime 지원
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO 8601 형식
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
     }
 }
 

--- a/src/main/java/com/project/team4backend/global/security/Config/S3Config.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/S3Config.java
@@ -1,0 +1,40 @@
+package com.project.team4backend.global.security.Config;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
@@ -9,7 +9,7 @@ import com.project.team4backend.global.security.handler.CustomLogoutHandler;
 import com.project.team4backend.global.security.handler.CustomLogoutSuccessHandler;
 import com.project.team4backend.global.security.handler.JwtAccessDeniedHandler;
 import com.project.team4backend.global.security.handler.JwtAuthenticationEntryPoint;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,7 +26,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration // 빈 등록
 @EnableWebSecurity // 필터 체인 관리 시작 어노테이션
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
@@ -37,6 +36,23 @@ public class SecurityConfig {
     private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
     private final RedisTemplate<String, String> redisTemplate;
 
+    public SecurityConfig(
+            AuthenticationConfiguration authenticationConfiguration,
+            JwtUtil jwtUtil,
+            JwtAccessDeniedHandler jwtAccessDeniedHandler,
+            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+            CustomLogoutHandler customLogoutHandler,
+            CustomLogoutSuccessHandler customLogoutSuccessHandler,
+            @Qualifier("tokenRedisTemplate") RedisTemplate<String, String> redisTemplate
+    ) {
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.customLogoutHandler = customLogoutHandler;
+        this.customLogoutSuccessHandler = customLogoutSuccessHandler;
+        this.redisTemplate = redisTemplate;
+    }
 
     //인증이 필요하지 않은 url
     private final String[] allowUrl = {

--- a/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/team4backend/global/security/handler/CustomLogoutHandler.java
@@ -6,8 +6,8 @@ import com.project.team4backend.global.security.JwtUtil;
 import com.project.team4backend.domain.auth.service.RefreshTokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,12 +20,19 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Component
 @Transactional
-@RequiredArgsConstructor
 public class CustomLogoutHandler implements LogoutHandler {
 
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
     private final RefreshTokenService refreshTokenService;
+
+    public CustomLogoutHandler(JwtUtil jwtUtil,
+                               RefreshTokenService refreshTokenService,
+                               @Qualifier("tokenRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshTokenService;
+        this.redisTemplate = redisTemplate;
+    }
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
     token:
-      access-expiration-time: 360000
+      access-expiration-time: 3600000
       refresh-expiration-time: 86400000
 
   mail:
@@ -38,6 +38,13 @@ spring:
       mail.smtp.auth: true
       mail.smtp.ssl.enable: true
       mail.smtp.ssl.trust: smtp.naver.com
+aws:
+  s3:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+    region: ${AWS_REGION}
+    bucket-name: ${AWS_S3_BUCKET}
+    presigned-url-duration: 10
 
 gpt.model: gpt-4.1-nano
 gpt.api.key: ${GPT_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ aws:
     secret-key: ${AWS_SECRET_KEY}
     region: ${AWS_REGION}
     bucket-name: ${AWS_S3_BUCKET}
-    presigned-url-duration: 10
+    presigned-url-duration: 15
 
 gpt.model: gpt-4.1-nano
 gpt.api.key: ${GPT_API_KEY}


### PR DESCRIPTION
# ☝️Issue Number

- #32 
##  📌 개요

- 프로필 이미지1 api 구현  (이미지 선택 시, presigned url, fileKey 발급)
- 프로필 이미지2 api 구현 (프론트에서 S3에 이미지 등록 후 실행하는 api, 맴버에 s3에 저장된 객체 url 저장)
- 이미지 스케줄러 구현 (redis에 저장된 fileKey중 1시간 동안 사용하지 않아서 만료된 경우 제거) 
## 🔁 변경 사항
- 이메일 인증 코드 보낼 때, email과 isdeleted 여부 확인을 해도 email 유일성에서 막길래, email 유일성 조건 제거 했습니다
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점