### PR TITLE
Feat/#18 게시글 이미지 등록 관련 api

### DIFF
--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -20,9 +20,10 @@ public class ImageConverter {
                 .build();
     }
 
-    public static ImageInternelDTO.ImageTrackingResDTO toImageTrackingResDTO(String fileKey) {
+    public static ImageInternelDTO.ImageTrackingResDTO toImageTrackingResDTO(String email, String fileKey) {
         return ImageInternelDTO.ImageTrackingResDTO.builder()
                 .fileKey(fileKey)
+                .email(email)
                 .createAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team4backend/domain/image/converter/ImageConverter.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,6 +19,9 @@ public class ImageConverter {
                 .presignedUrl(presignedUrl)
                 .fileKey(fileKey)
                 .build();
+    }
+    public static ImageResDTO.PresignedUrlListResDTO toPresignedUrlListResDTO(List<ImageResDTO.PresignedUrlResDTO> urls) {
+        return new ImageResDTO.PresignedUrlListResDTO(urls);
     }
 
     public static ImageInternelDTO.ImageTrackingResDTO toImageTrackingResDTO(String email, String fileKey) {

--- a/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/internel/ImageInternelDTO.java
@@ -8,6 +8,7 @@ public class ImageInternelDTO {
     @Builder
     public record ImageTrackingResDTO (
             String fileKey,
+            String email,
             LocalDateTime createAt
     ){}
 }

--- a/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
@@ -2,6 +2,8 @@ package com.project.team4backend.domain.image.dto.request;
 
 import lombok.Builder;
 
+import java.util.List;
+
 public class ImageReqDTO {
     @Builder
     public record PresignedUrlReqDTO(
@@ -9,6 +11,12 @@ public class ImageReqDTO {
             String contentType
     ) {
     }
+
+    @Builder
+    public record PresignedUrlListReqDTO(
+            List<PresignedUrlReqDTO> images // 각 이미지마다 contentType, fileExtension
+    ){}
+
     @Builder
     public record SaveImageReqDTO(
             String fileKey

--- a/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/request/ImageReqDTO.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 
 public class ImageReqDTO {
     @Builder
-    public record PresignedUrlDTO(
+    public record PresignedUrlReqDTO(
             String fileExtension,
             String contentType
     ) {
     }
     @Builder
     public record SaveImageReqDTO(
-            String profileImageUrl
+            String fileKey
     ){
     }
 }

--- a/src/main/java/com/project/team4backend/domain/image/dto/response/ImageResDTO.java
+++ b/src/main/java/com/project/team4backend/domain/image/dto/response/ImageResDTO.java
@@ -3,6 +3,8 @@ package com.project.team4backend.domain.image.dto.response;
 
 import lombok.Builder;
 
+import java.util.List;
+
 
 public class ImageResDTO {
     @Builder
@@ -11,6 +13,11 @@ public class ImageResDTO {
             String fileKey
     ){
     }
+
+    @Builder
+    public record PresignedUrlListResDTO (
+            List<PresignedUrlResDTO> presignedUrls
+    ){}
 
     @Builder
     public record SaveImageResDTO (

--- a/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
@@ -12,6 +12,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE_400_2", "지원하지 않는 콘텐츠 타입입니다."),
     IMAGE_KEY_MISSING(HttpStatus.BAD_REQUEST, "IMAGE_400_3","이미지 키가 누락되었습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_404_1", "S3에 이미지를 찾을 수 없습니다."),
+    IMAGE_INVALID_FILE_KEY(HttpStatus.NOT_FOUND, "IMAGE_400_5", "해당 유저의 fileKey가 존재하지 않습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_1", "이미지 업로드에 실패했습니다."),
     IMAGE_COMMIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_2", "이미지 커밋에 실패했습니다."),
     IMAGE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_3", "이미지 삭제에 실패했습니다."),

--- a/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team4backend/domain/image/exception/ImageErrorCode.java
@@ -11,6 +11,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "IMAGE_400_1", "지원하지 않는 파일 확장자입니다."),
     IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE_400_2", "지원하지 않는 콘텐츠 타입입니다."),
     IMAGE_KEY_MISSING(HttpStatus.BAD_REQUEST, "IMAGE_400_3","이미지 키가 누락되었습니다."),
+    IMAGE_TOO_MANY_REQUESTS(HttpStatus.BAD_REQUEST, "IMAGE_400_4", "이미지 파일이 5개를 넘었습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_404_1", "S3에 이미지를 찾을 수 없습니다."),
     IMAGE_INVALID_FILE_KEY(HttpStatus.NOT_FOUND, "IMAGE_400_5", "해당 유저의 fileKey가 존재하지 않습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_1", "이미지 업로드에 실패했습니다."),

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -4,10 +4,11 @@ import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 
 public interface ImageCommandService {
-    ImageResDTO.PresignedUrlResDTO generatePresignedUrl(ImageReqDTO.PresignedUrlDTO presignedUrl);
+    ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlDTO presignedUrl);
 
     String commit(String fileKey);
 
-    void delete(String fileKey);
+    String commit(String email, String fileKey);
 
+    void delete(String email, String fileKey);
 }

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -4,7 +4,7 @@ import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 
 public interface ImageCommandService {
-    ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlDTO presignedUrl);
+    ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrl);
 
     String commit(String fileKey);
 

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandService.java
@@ -6,7 +6,7 @@ import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 public interface ImageCommandService {
     ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrl);
 
-    String commit(String fileKey);
+    ImageResDTO.PresignedUrlListResDTO generatePresignedUrlList(String email, ImageReqDTO.PresignedUrlListReqDTO presignedUrlListReqDTO);
 
     String commit(String email, String fileKey);
 

--- a/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/command/ImageCommandServiceImpl.java
@@ -49,11 +49,25 @@ public class ImageCommandServiceImpl implements ImageCommandService {
     public ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlDTO presignedUrlDTO) {
         validateFileExtension(presignedUrlDTO.fileExtension());
         validateContentType(presignedUrlDTO.contentType());
+    public ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrlReqDTO) {
+        return generateSinglePresignedUrl(email, presignedUrlReqDTO);
+    }
 
-        String fileKey = generateFileKey(presignedUrlDTO.fileExtension());
+
+    /**
+     * 단일 Presigned URL 생성 공통 메서드
+     * @param email 사용자 이메일
+     * @param presignedUrlReqDTO 요청 DTO
+     * @return Presigned URL 응답 DTO
+     */
+    private ImageResDTO.PresignedUrlResDTO generateSinglePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrlReqDTO) {
+        validateFileExtension(presignedUrlReqDTO.fileExtension());
+        validateContentType(presignedUrlReqDTO.contentType());
+
+        String fileKey = generateFileKey(presignedUrlReqDTO.fileExtension());
 
         try {
-            PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucketName, fileKey, presignedUrlDTO.contentType());
+            PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucketName, fileKey, presignedUrlReqDTO.contentType());
 
             PutObjectPresignRequest presignRequest = ImageConverter.toPutObjectPresignRequest(Duration.ofMinutes(presignedUrlDurationMinutes), putObjectRequest);
 

--- a/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
+++ b/src/main/java/com/project/team4backend/domain/image/service/scheduler/ImageScheduler.java
@@ -1,4 +1,5 @@
 package com.project.team4backend.domain.image.service.scheduler;
+import com.project.team4backend.domain.image.dto.internel.ImageInternelDTO;
 import com.project.team4backend.domain.image.exception.ImageErrorCode;
 import com.project.team4backend.domain.image.exception.ImageException;
 import com.project.team4backend.domain.image.service.RedisImageTracker;
@@ -29,24 +30,24 @@ public class ImageScheduler {
         try {
             // 1시간 전 이전에 생성된 추적 정보 조회
             LocalDateTime expiredBefore = LocalDateTime.now().minusHours(1);
-            Set<String> expiredFileKeys = redisImageTracker.getExpiredFileKeys(expiredBefore);
+            Set<ImageInternelDTO.ImageTrackingResDTO> expiredImages = redisImageTracker.getExpiredImageEntries(expiredBefore);
 
-            if (expiredFileKeys.isEmpty()) {
+            if (expiredImages.isEmpty()) {
                 log.info("정리할 FileKey가 없습니다.");
                 return;
             }
 
-            log.info("총 {}개의 만료 FileKey 정리 시도", expiredFileKeys.size());
+            log.info("총 {}개의 만료 FileKey 정리 시도", expiredImages.size());
 
             int deletedCount = 0;
             int errorCount = 0;
 
-            for (String fileKey : expiredFileKeys) {
+            for (ImageInternelDTO.ImageTrackingResDTO dto : expiredImages) {
                 try {
-                    imageCommandService.delete(fileKey);
+                    imageCommandService.delete(dto.email(), dto.fileKey());
                     deletedCount++;
                 } catch (Exception e) {
-                    log.error("만료 FileKey 삭제 실패: {}", fileKey, e);
+                    log.error("만료 FileKey 삭제 실패: {}", dto.fileKey(), e);
                     errorCount++;
                 }
             }

--- a/src/main/java/com/project/team4backend/domain/member/entity/Member.java
+++ b/src/main/java/com/project/team4backend/domain/member/entity/Member.java
@@ -40,12 +40,9 @@ public class Member extends BaseEntity {
         this.isDeleted = true;
     }
 
-    public void selectImage(String fileKey) {
+    public void saveImage(String imageUrl, String fileKey) {
+        this.profileImageUrl = imageUrl;
         this.profileImageKey = fileKey;
-    }
-
-    public void saveImage(String ImageUrl) {
-        this.profileImageUrl = ImageUrl;
     }
 
     public void deleteProfileImage() {

--- a/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/team4backend/domain/member/service/command/MemberCommandService.java
@@ -1,14 +1,10 @@
 package com.project.team4backend.domain.member.service.command;
 
-import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team4backend.domain.image.dto.response.ImageResDTO;
 import com.project.team4backend.domain.member.dto.request.MemberReqDTO;
-import com.project.team4backend.domain.member.entity.Member;
 
 public interface MemberCommandService {
-    void selectProfileImage(String email, String fileKey);
-
-    ImageResDTO.SaveImageResDTO saveProfileImage(Member member, String fileKey, String ImageUrl, ImageReqDTO.SaveImageReqDTO saveImageReqDTO);
+    ImageResDTO.SaveImageResDTO uploadProfileImage(String email, String fileKey, String imageUrl);
 
     String updateMemberAccount(String email, MemberReqDTO.MemberAccountUpdateReqDTO memberAccountUpdateReqDTO);
 

--- a/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
@@ -1,10 +1,14 @@
 package com.project.team4backend.domain.post.controller;
 
+import com.project.team4backend.domain.image.dto.request.ImageReqDTO;
+import com.project.team4backend.domain.image.dto.response.ImageResDTO;
+import com.project.team4backend.domain.image.service.command.ImageCommandService;
 import com.project.team4backend.domain.post.dto.reponse.PostResDTO;
 import com.project.team4backend.domain.post.dto.request.PostReqDTO;
 import com.project.team4backend.domain.post.service.command.PostCommandService;
 import com.project.team4backend.domain.post.service.query.PostQueryService;
 import com.project.team4backend.global.apiPayload.CustomResponse;
+import com.project.team4backend.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,7 +30,7 @@ public class PostController {
     private final ImageCommandService imageCommandService;
 
     @PostMapping
-    @Operation(summary = "게시글 등록", description = "회원이 새로운 게시글을 등록합니다.")
+    @Operation(summary = "게시글 등록", description = "회원이 새로운 게시글을 등록합니다., 이미지 첨부 안할거면 images: []로 dto 제출하면 된다.")
     public CustomResponse<PostResDTO.PostCreateResDTO> createPost(
             @RequestBody @Valid PostReqDTO.PostCreateReqDTO dto,
             @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
@@ -49,25 +49,24 @@ public class PostController {
 
     @PutMapping("/{postId}")
     @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
-    public CustomResponse<Void> updatePost(
+    public CustomResponse<PostResDTO.PostUpdateResDTO> updatePost(
             @PathVariable Long postId,
             @RequestBody @Valid PostReqDTO.PostUpdateReqDTO dto,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         String email = userDetails.getUsername();
-        postCommandService.updatePost(postId, dto, email);
-        return CustomResponse.onSuccess(null);
+        PostResDTO.PostUpdateResDTO postUpdateResDTO = postCommandService.updatePost(postId, dto, email);
+        return CustomResponse.onSuccess(postUpdateResDTO);
     }
 
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    public CustomResponse<Void> deletePost(
+    public CustomResponse<PostResDTO.PostDeleteResDTO> deletePost(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserDetails userDetails) {
 
         String email = userDetails.getUsername();
-        postCommandService.deletePost(postId, email);
-
-        return CustomResponse.onSuccess(null);
+        PostResDTO.PostDeleteResDTO postDeleteResDTO = postCommandService.deletePost(postId, email);
+        return CustomResponse.onSuccess(postDeleteResDTO);
     }
 }

--- a/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/team4backend/domain/post/controller/PostController.java
@@ -23,6 +23,7 @@ public class PostController {
 
     private final PostCommandService postCommandService;
     private final PostQueryService postQueryService;
+    private final ImageCommandService imageCommandService;
 
     @PostMapping
     @Operation(summary = "게시글 등록", description = "회원이 새로운 게시글을 등록합니다.")
@@ -33,6 +34,15 @@ public class PostController {
         String email = userDetails.getUsername();
         PostResDTO.PostCreateResDTO response = postCommandService.createPost(dto, email);
         return CustomResponse.onSuccess(response);
+    }
+
+    @Operation(method = "POST", summary = "게시글 이미지 업로드", description = "게시글 이미지 선택 api, 업로드 하는건 아님, presignedUrl을 발급")
+    @PostMapping("/postImage")
+    public CustomResponse<ImageResDTO.PresignedUrlListResDTO> uploadPostImages
+            (@AuthenticationPrincipal CustomUserDetails customUserDetails,
+             @RequestBody ImageReqDTO.PresignedUrlListReqDTO presignedUrlListReqDTO) {
+        ImageResDTO.PresignedUrlListResDTO presignedUrlListResDTO = imageCommandService.generatePresignedUrlList(customUserDetails.getEmail(), presignedUrlListReqDTO); // presignedUrl 발급
+        return CustomResponse.onSuccess(presignedUrlListResDTO);
     }
 
 

--- a/src/main/java/com/project/team4backend/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/project/team4backend/domain/post/converter/PostConverter.java
@@ -6,6 +6,8 @@ import com.project.team4backend.domain.post.dto.request.PostReqDTO;
 import com.project.team4backend.domain.post.entity.Post;
 import com.project.team4backend.domain.post.entity.PostImage;
 
+import java.util.List;
+
 public class PostConverter {
     public static Post toEntity(PostReqDTO.PostCreateReqDTO req, Member member) {
         Post post = Post.builder()
@@ -50,6 +52,26 @@ public class PostConverter {
                 .createdAt(post.getCreatedAt())
                 .build();
     }
+
+    public static PostResDTO.PostCreateResDTO toCreateDTO(Post post) {
+        return PostResDTO.PostCreateResDTO.builder()
+                .postId(post.getPostId())
+                .message("게시글이 등록되었습니다.")
+                .build();
+    }
+
+    public static List<PostImage> toImageEntities(List<PostReqDTO.PostUpdateReqDTO.ImageDTO> imageDTOs, Post post) {
+        if (imageDTOs == null) return List.of();
+
+        return imageDTOs.stream()
+                .map(dto -> PostImage.builder()
+                        .imageUrl(dto.imageUrl())
+                        .imageUrlKey(dto.imageUrlKey())
+                        .post(post)
+                        .build())
+                .toList();
+    }
+
     public static PostResDTO.PostUpdateResDTO toUpdateDTO(Post post) {
         return PostResDTO.PostUpdateResDTO.builder()
                 .postId(post.getPostId())

--- a/src/main/java/com/project/team4backend/domain/post/entity/Post.java
+++ b/src/main/java/com/project/team4backend/domain/post/entity/Post.java
@@ -51,24 +51,17 @@ public class Post extends BaseEntity {
 
     public void addImage(PostImage image) {
         this.images.add(image);
-        image.setPost(this); // 양쪽 다 맞춰줌 양방향 동기화 매서드
+        image.updatePost(this); // 양쪽 다 맞춰줌 양방향 동기화 매서드
     }
 
-    public void update(String title, String content, Set<PostTagType> tags, List<PostReqDTO.PostUpdateReqDTO.ImageDTO> imageDTOs) {
+    public void update(String title, String content, Set<PostTagType> tags, List<PostImage> newImages) {
         this.title = title;
         this.content = content;
         this.tags = tags;
 
         this.images.clear();
-        if (imageDTOs != null) {
-            imageDTOs.forEach(dto -> {
-                PostImage image = PostImage.builder()
-                        .imageUrl(dto.imageUrl())
-                        .imageUrlKey(dto.imageUrlKey())
-                        .post(this) // 연관관계 설정
-                        .build();
-                this.images.add(image);
-            });
+        if (newImages != null) {
+            newImages.forEach(this::addImage); // 양방향 연관관계 유지
         }
     }
 }

--- a/src/main/java/com/project/team4backend/domain/post/entity/PostImage.java
+++ b/src/main/java/com/project/team4backend/domain/post/entity/PostImage.java
@@ -27,7 +27,7 @@ public class PostImage extends BaseEntity {
     private Post post;
 
     // 양방향 연관관계 편의용(동기화) setter
-    public void setPost(Post post) {
+    public void updatePost(Post post) {
         this.post = post;
     }
 

--- a/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
@@ -115,6 +115,8 @@ public class PostCommandServiceImpl implements PostCommandService {
         if (!post.getMember().equals(member)) {
             throw new PostException(PostErrorCode.UNAUTHORIZED_POST_DELETE);
         }
+        // s3 + redis  모든 이미지 삭제
+        post.getImages().forEach(image -> imageCommandService.delete(email, image.getImageUrlKey()));
 
         // 4. 삭제
         postRepository.delete(post);

--- a/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
@@ -33,10 +33,7 @@ public class PostCommandServiceImpl implements PostCommandService {
 
         Post saved = postRepository.save(post);
 
-        return PostResDTO.PostCreateResDTO.builder()
-                .postId(saved.getPostId())
-                .message("게시글이 등록되었습니다.")
-                .build();
+        return PostConverter.toCreateDTO(saved);
     }
 
     @Override

--- a/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/post/service/command/PostCommandServiceImpl.java
@@ -1,17 +1,22 @@
 package com.project.team4backend.domain.post.service.command;
 
 import com.project.team4backend.domain.member.entity.Member;
+import com.project.team4backend.domain.member.exception.MemberErrorCode;
+import com.project.team4backend.domain.member.exception.MemberException;
 import com.project.team4backend.domain.member.repository.MemberRepository;
 import com.project.team4backend.domain.post.converter.PostConverter;
 import com.project.team4backend.domain.post.dto.reponse.PostResDTO;
 import com.project.team4backend.domain.post.dto.request.PostReqDTO;
 import com.project.team4backend.domain.post.entity.Post;
+import com.project.team4backend.domain.post.entity.PostImage;
 import com.project.team4backend.domain.post.exception.PostErrorCode;
 import com.project.team4backend.domain.post.exception.PostException;
 import com.project.team4backend.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -39,7 +44,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     @Override
     public PostResDTO.PostUpdateResDTO updatePost(Long postId, PostReqDTO.PostUpdateReqDTO dto, String email) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new PostException(PostErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
@@ -49,7 +54,8 @@ public class PostCommandServiceImpl implements PostCommandService {
         }
 
         // update는 Post 엔티티 내부 메서드로 실행
-        post.update(dto.title(), dto.content(), dto.tags(), dto.images());
+        List<PostImage> images = PostConverter.toImageEntities(dto.images(), post);
+        post.update(dto.title(), dto.content(), dto.tags(), images);
 
         return PostConverter.toUpdateDTO(post);
     }
@@ -58,7 +64,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     public PostResDTO.PostDeleteResDTO deletePost(Long postId, String email) {
         // 1. 사용자 조회
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new PostException(PostErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 2. 게시글 조회 (작성자와 이미지 fetch)
         Post post = postRepository.findById(postId)

--- a/src/main/java/com/project/team4backend/domain/post/service/query/PostQueryServiceImpl.java
+++ b/src/main/java/com/project/team4backend/domain/post/service/query/PostQueryServiceImpl.java
@@ -1,14 +1,17 @@
 package com.project.team4backend.domain.post.service.query;
 
 import com.project.team4backend.domain.member.entity.Member;
+import com.project.team4backend.domain.member.exception.MemberErrorCode;
+import com.project.team4backend.domain.member.exception.MemberException;
 import com.project.team4backend.domain.member.repository.MemberRepository;
 import com.project.team4backend.domain.post.converter.PostConverter;
 import com.project.team4backend.domain.post.dto.reponse.PostResDTO;
 import com.project.team4backend.domain.post.entity.Post;
+import com.project.team4backend.domain.post.exception.PostErrorCode;
+import com.project.team4backend.domain.post.exception.PostException;
 import com.project.team4backend.domain.post.repository.PostLikeRepository;
 import com.project.team4backend.domain.post.repository.PostRepository;
 import com.project.team4backend.domain.post.repository.PostScrapRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,10 +29,10 @@ public class PostQueryServiceImpl implements PostQueryService {
     @Override
     public PostResDTO.PostDetailResDTO getPostDetail(Long postId, String email) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("Post not found"));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
         boolean liked = postLikeRepository.existsByPostAndMember(post, member);
         boolean scrapped = postScrapRepository.existsByPostAndMember(post, member);


### PR DESCRIPTION
# ☝️Issue Number

- #37 
##  📌 개요

- 게시글 이미지 등록 api
- 게시글 생성 api 리팩토링 (이미지 첨부 시)
- 게시글 수정 api 리펙토링 (이미지 추가 or 삭제 시)
- 게시글 삭제 api 리펙토링 (s3 + redis 정보 제거)

## 🔁 변경 사항
- 관심사 분리에 따른 예외처리 적용
- 원래는 프로필 이미지만 구현했을때, redis에 fileKey 값만 저장하는 방식이었는데,  post에 이미지 첨부시에는 존재 하지 않는 post에 fileKey를 저장할 수 없어서 user.email:fileKey 형태로 redis에 저장되게 해서 email을 통해 사용자의 fileKey인지 확인하도록 변경했습니다.
## 📸 스크린샷
- 기존 redis에 presignedUrl fileKey 저장방식
![image](https://github.com/user-attachments/assets/ce3dd416-d9d7-4e28-a642-7e4e93d4387e)
- 변경 후 저장방식
![image](https://github.com/user-attachments/assets/c6903897-ae6b-4c27-9fa1-7127c94bdeb6)

## 👀 기타 더 이야기해볼 점