### PR TITLE
🐛fix: 게시판 삭제시 댓글이 달려있으면 삭제되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/project/team4backend/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/project/team4backend/domain/comment/repository/CommentLikeRepository.java
@@ -5,7 +5,11 @@ import com.project.team4backend.domain.comment.entity.CommentLike;
 import com.project.team4backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    void deleteAllByCommentIn(List<Comment> comments);
 
     boolean existsByMemberAndComment(Member member, Comment comment);
 }


### PR DESCRIPTION
# ☝️Issue Number

- 🐛fix: 게시판 삭제시 댓글이 달려있으면 삭제되지 않는 버그 수정

##  📌 개요

-🐛fix: 게시판 삭제시 댓글이 달려있으면 삭제되지 않는 버그 수정

## 🔁 변경 사항
게시글을 삭제하기전 댓글, 댓글 좋아요 기록부터 db에서 삭제하도록 변경
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점