### PR TITLE
🐛fix: 프론트 연동 url CorsConfig에 추가 후 securityConfig filter에 적용

### DIFF
--- a/src/main/java/com/project/team4backend/domain/auth/entity/SocialLogin.java
+++ b/src/main/java/com/project/team4backend/domain/auth/entity/SocialLogin.java
@@ -13,7 +13,10 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "social_login")
+@Table(
+        name = "social_login",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"social_type", "social_id"}) // 소셜이 다르면 social_id가 겹칠 수 있음
+)
 public class SocialLogin extends BaseEntity {
 
     @Id

--- a/src/main/java/com/project/team4backend/global/security/Config/CorsConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/CorsConfig.java
@@ -22,6 +22,7 @@ public class CorsConfig implements WebMvcConfigurer {
         ArrayList<String> allowedOriginPatterns = new ArrayList<>();
         allowedOriginPatterns.add("http://localhost:8080");
         allowedOriginPatterns.add("http://localhost:3000");
+        allowedOriginPatterns.add("http://localhost:5500");
         allowedOriginPatterns.add("http://127.0.0.1:8080");
         allowedOriginPatterns.add("http://127.0.0.1:3000");
         allowedOriginPatterns.add("http://127.0.0.1:5500");
@@ -31,6 +32,7 @@ public class CorsConfig implements WebMvcConfigurer {
         ArrayList<String> allowedHttpMethods = new ArrayList<>();
         allowedHttpMethods.add("GET");
         allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PATCH");
         allowedHttpMethods.add("PUT");
         allowedHttpMethods.add("DELETE");
 

--- a/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
+++ b/src/main/java/com/project/team4backend/global/security/Config/SecurityConfig.java
@@ -75,6 +75,7 @@ public class SecurityConfig {
         loginFilter.setFilterProcessesUrl("/api/v1/auths/login");
 
         http
+                .cors(cors -> cors.configurationSource(CorsConfig.apiConfigurationSource()))
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/", "/index", "/css/**", "/js/**", "/images/**").permitAll()
                         .requestMatchers(allowUrl).permitAll()


### PR DESCRIPTION
# ☝️Issue Number

- #51 

##  📌 개요

- corsconfig에 url 추가 이후 securityconfig의 filter에 cors 허용 코드 추가 

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점